### PR TITLE
chore(sdk/python): drop unused volcengine-python-sdk dependency

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -83,27 +83,6 @@ generated from the sandbox OpenAPI spec.
 - `client.proxy` — outbound proxy routing
 - `client.auth` / `client.util` — helpers
 
-## Cloud Providers
-
-### Volcengine
-
-See [`examples/volcengine-provider`](https://github.com/ProwlrBot/CyberBox/tree/main/examples/volcengine-provider)
-for the full script.
-
-```python
-import os
-from agent_sandbox.providers import VolcengineProvider
-
-provider = VolcengineProvider(
-    access_key=os.environ["VOLC_ACCESSKEY"],
-    secret_key=os.environ["VOLC_SECRETKEY"],
-    region=os.environ.get("VOLCENGINE_REGION", "cn-beijing"),
-)
-
-sandbox_id = provider.create_sandbox(function_id="yatoczqh")
-print("sandbox:", sandbox_id)
-```
-
 ## Requirements
 
 - Python 3.8+

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -42,7 +42,6 @@ dependencies = [
     "httpx[socks]>=0.23.0,<1",
     "pydantic>=1.9.0,<3",
     "typing_extensions>=4.0.0; python_version < '3.10'",
-    "volcengine-python-sdk>=4.0.17",
 ]
 
 [project.urls]

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "agent-sandbox"
-version = "0.0.20"
+version = "0.0.27"
 source = { editable = "." }
 dependencies = [
     { name = "httpx", extra = ["socks"] },
@@ -16,7 +16,6 @@ dependencies = [
     { name = "pydantic", version = "2.11.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
-    { name = "volcengine-python-sdk" },
 ]
 
 [package.metadata]
@@ -24,7 +23,6 @@ requires-dist = [
     { name = "httpx", extras = ["socks"], specifier = ">=0.23.0,<1" },
     { name = "pydantic", specifier = ">=1.9.0,<3" },
     { name = "typing-extensions", marker = "python_full_version < '3.10'", specifier = ">=4.0.0" },
-    { name = "volcengine-python-sdk", specifier = ">=4.0.17" },
 ]
 
 [[package]]
@@ -410,27 +408,6 @@ wheels = [
 ]
 
 [[package]]
-name = "python-dateutil"
-version = "2.9.0.post0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
-]
-
-[[package]]
-name = "six"
-version = "1.17.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
-]
-
-[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -482,44 +459,4 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f8/b1/0c11f5058406b3af7609f121aaa6b609744687f1d158b3c3a5bf4cc94238/typing_inspection-0.4.1.tar.gz", hash = "sha256:6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28", size = 75726, upload-time = "2025-05-21T18:55:23.885Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/17/69/cd203477f944c353c31bade965f880aa1061fd6bf05ded0726ca845b6ff7/typing_inspection-0.4.1-py3-none-any.whl", hash = "sha256:389055682238f53b04f7badcb49b989835495a96700ced5dab2d8feae4b26f51", size = 14552, upload-time = "2025-05-21T18:55:22.152Z" },
-]
-
-[[package]]
-name = "urllib3"
-version = "2.2.3"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.9'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/63/22ba4ebfe7430b76388e7cd448d5478814d3032121827c12a2cc287e2260/urllib3-2.2.3.tar.gz", hash = "sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9", size = 300677, upload-time = "2024-09-12T10:52:18.401Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/d9/5f4c13cecde62396b0d3fe530a50ccea91e7dfc1ccf0e09c228841bb5ba8/urllib3-2.2.3-py3-none-any.whl", hash = "sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac", size = 126338, upload-time = "2024-09-12T10:52:16.589Z" },
-]
-
-[[package]]
-name = "urllib3"
-version = "2.5.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.9'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
-]
-
-[[package]]
-name = "volcengine-python-sdk"
-version = "4.0.17"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "python-dateutil" },
-    { name = "six" },
-    { name = "urllib3", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "urllib3", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/c8/3e5a528fba6dffb1e43cc614bd1672947b1b31aa66f847deccf933f09dee/volcengine-python-sdk-4.0.17.tar.gz", hash = "sha256:a0fb904d3eb373e7e2f38bd2344baa06e3c16cc76e3cbac78c8e73e13d59e7c7", size = 5789604, upload-time = "2025-09-09T09:02:10.955Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/2b/d9e3d88dffcceedf55d3503fe5245a6659f58b35b3d6c2b5c63fca90e820/volcengine_python_sdk-4.0.17-py2.py3-none-any.whl", hash = "sha256:6c3e5e85bd339086ab209a20fa375bf50cf5fe98ed683b18a945f26e0a33eba0", size = 22279788, upload-time = "2025-09-09T09:02:06.966Z" },
 ]


### PR DESCRIPTION
## Summary

`volcengine-python-sdk>=4.0.17` was a dead dependency inherited from the upstream `agent-infra/sandbox` fork. It pulls in a 6MB wheel plus transitive `python-dateutil` / `six` / `urllib3` pins, but is never imported anywhere under `sdk/python/agent_sandbox/`.

## What changed
- Removed `volcengine-python-sdk>=4.0.17` from `sdk/python/pyproject.toml`.
- Regenerated `sdk/python/uv.lock` (drops volcengine + 4 transitive deps).
- Removed the \"Cloud Providers / Volcengine\" section from `sdk/python/README.md` — it advertised `from agent_sandbox.providers import VolcengineProvider`, but that module does not exist in the Python SDK (unlike the JS SDK, which does ship `providers/`). That import path has never worked on our fork.

## Verification
```bash
grep -rn "volcengine" sdk/python/agent_sandbox/
# → (no matches)
```

## Follow-ups (not in this PR)
- `examples/volcengine-provider/main.py` still imports the nonexistent `agent_sandbox.providers` module. That example was broken before this change and remains broken. Either:
  1. Port the JS SDK's `providers/` to Python, or
  2. Delete the example directory.
- `examples/volcengine-provider/uv.lock` will go stale against the new `agent-sandbox` release until (1) or (2) lands.

## Test plan
- [ ] `uv pip install -e sdk/python` resolves without volcengine.
- [ ] `python -c \"from agent_sandbox import Sandbox; Sandbox(base_url='http://x')\"` still works.
- [ ] Release the next `agent-sandbox` with a minor version bump (0.0.28).

🤖 Generated with [Claude Code](https://claude.com/claude-code)