### PR TITLE
ci(sdk/python): add pytest + mypy CI and smoke tests

### DIFF
--- a/.github/workflows/sdk-ci.yml
+++ b/.github/workflows/sdk-ci.yml
@@ -5,11 +5,13 @@ on:
     branches: [main]
     paths:
       - 'sdk/js/**'
+      - 'sdk/python/**'
       - '.github/workflows/sdk-ci.yml'
   pull_request:
     branches: [main]
     paths:
       - 'sdk/js/**'
+      - 'sdk/python/**'
       - '.github/workflows/sdk-ci.yml'
 
 permissions:
@@ -45,3 +47,37 @@ jobs:
       - name: Run tests
         run: pnpm test
         working-directory: sdk/js
+
+  python-sdk:
+    name: Python SDK (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.12']
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Python SDK with dev extras
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e '.[dev]'
+        working-directory: sdk/python
+
+      - name: Run pytest
+        run: pytest -v
+        working-directory: sdk/python
+
+      - name: Run mypy (informational)
+        run: mypy agent_sandbox
+        working-directory: sdk/python
+        continue-on-error: true

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -45,9 +45,27 @@ dependencies = [
     "volcengine-python-sdk>=4.0.17",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0,<9.0",
+    "mypy>=1.0,<2.0",
+]
+
 [project.urls]
 Homepage = "https://github.com/ProwlrBot/CyberBox"
 Repository = "https://github.com/ProwlrBot/CyberBox"
 Documentation = "https://github.com/ProwlrBot/CyberBox/tree/main/sdk/python#readme"
 Issues = "https://github.com/ProwlrBot/CyberBox/issues"
 Changelog = "https://github.com/ProwlrBot/CyberBox/releases"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+
+[tool.mypy]
+python_version = "3.10"
+ignore_missing_imports = true
+# Fern-generated code uses a lot of Any; keep mypy pragmatic on the SDK.
+# CI currently runs mypy as informational (continue-on-error) until the
+# generated surface is cleaned up.
+warn_unused_ignores = false

--- a/sdk/python/tests/test_smoke.py
+++ b/sdk/python/tests/test_smoke.py
@@ -1,0 +1,57 @@
+"""Smoke tests for the agent-sandbox Python SDK.
+
+These do not hit a live sandbox. They verify the package surface is
+importable and the client constructors accept their documented kwargs
+without raising. If the Fern regeneration breaks public API shape, these
+tests fail and catch it before it ships.
+"""
+
+from __future__ import annotations
+
+import agent_sandbox
+
+
+def test_top_level_exports() -> None:
+    """The two documented entry points must be importable from the root."""
+    assert hasattr(agent_sandbox, "Sandbox")
+    assert hasattr(agent_sandbox, "AsyncSandbox")
+
+
+def test_sync_client_constructs() -> None:
+    """Sandbox() must accept the documented kwargs and produce a client."""
+    client = agent_sandbox.Sandbox(base_url="http://localhost:8080", timeout=5.0)
+    assert client is not None
+    # Namespaces promised in the README.
+    for name in ("sandbox", "shell", "bash", "file", "jupyter", "nodejs",
+                 "mcp", "browser", "skills", "proxy", "auth"):
+        assert hasattr(client, name), f"client.{name} missing"
+
+
+def test_async_client_constructs() -> None:
+    """AsyncSandbox() must accept the documented kwargs and produce a client."""
+    client = agent_sandbox.AsyncSandbox(base_url="http://localhost:8080", timeout=5.0)
+    assert client is not None
+    for name in ("sandbox", "shell", "file", "jupyter", "mcp"):
+        assert hasattr(client, name), f"async client.{name} missing"
+
+
+def test_documented_shell_method_name() -> None:
+    """README advertises client.shell.exec_command — protect against rename drift."""
+    client = agent_sandbox.Sandbox(base_url="http://localhost:8080")
+    assert hasattr(client.shell, "exec_command")
+    assert hasattr(client.shell, "view")
+
+
+def test_documented_file_methods() -> None:
+    """README advertises read_file / write_file / list_path."""
+    client = agent_sandbox.Sandbox(base_url="http://localhost:8080")
+    for name in ("read_file", "write_file", "list_path", "find_files",
+                 "search_in_file", "grep_files"):
+        assert hasattr(client.file, name), f"client.file.{name} missing"
+
+
+def test_documented_mcp_methods() -> None:
+    """README advertises list_mcp_servers / list_mcp_tools / execute_mcp_tool."""
+    client = agent_sandbox.Sandbox(base_url="http://localhost:8080")
+    for name in ("list_mcp_servers", "list_mcp_tools", "execute_mcp_tool"):
+        assert hasattr(client.mcp, name), f"client.mcp.{name} missing"


### PR DESCRIPTION
## Summary

SDK CI was JS-only. Adding Python parity so regressions in the Fern-generated client or `pyproject.toml` deps are caught in CI instead of at release time.

## What's new

### Workflow
- `.github/workflows/sdk-ci.yml` gains a `python-sdk` job.
- Matrix: Python 3.10 and 3.12.
- Installs the SDK with `pip install -e '.[dev]'`, runs pytest (required), runs mypy (informational — `continue-on-error: true`).
- Path filter extended to `sdk/python/**`.

### Package
- `sdk/python/pyproject.toml` gains `[project.optional-dependencies] dev = [pytest>=7, mypy>=1.0]`, plus pytest + mypy config blocks.
- `sdk/python/tests/test_smoke.py` — 6 smoke tests guarding the documented public API surface:
  - Top-level `Sandbox` / `AsyncSandbox` exports.
  - All namespaces on both clients (`shell`, `file`, `jupyter`, `mcp`, etc.).
  - Method names the README advertises: `shell.exec_command`, `shell.view`, `file.read_file` / `write_file` / `list_path` / `find_files` / `search_in_file` / `grep_files`, `mcp.list_mcp_servers` / `list_mcp_tools` / `execute_mcp_tool`.

These tests catch method-name drift from future Fern regenerations before it leaks into README or examples.

## Why mypy is informational
Fern-generated code uses lots of `Any` and `TYPE_CHECKING` lazy imports. Turning mypy into a hard gate would require cleaning up the generated surface first. For now the job logs mypy output but does not fail on it.

## Local verification
```
$ cd sdk/python && pip install -e '.[dev]' && pytest -v
6 passed in 0.30s
```

## Test plan
- [ ] `python-sdk (3.10)` job turns green on this PR.
- [ ] `python-sdk (3.12)` job turns green.
- [ ] `js-sdk` job still runs and remains green.
- [ ] mypy step runs but does not fail the job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)