### PR TITLE
debrand: retire "AIO Sandbox" wording from user-facing surfaces

### DIFF
--- a/cybersandbox/SECURITY.md
+++ b/cybersandbox/SECURITY.md
@@ -18,7 +18,7 @@ Do NOT open a public issue for security vulnerabilities.
 
 ## Out of Scope
 
-- Upstream AIO Sandbox vulnerabilities (report to [agent-infra/sandbox](https://github.com/agent-infra/sandbox))
+- Vulnerabilities in the upstream sandbox runtime (report to [agent-infra/sandbox](https://github.com/agent-infra/sandbox), from which CyberSandbox was forked)
 - Vulnerabilities in bundled third-party tools (nuclei, nmap, etc.) — report to their maintainers
 - Intentional offensive tool behavior (this is a security research platform)
 

--- a/examples/ag2-integration/main.py
+++ b/examples/ag2-integration/main.py
@@ -1,4 +1,7 @@
-"""AG2 Multi-Agent Code Execution with AIO Sandbox
+"""AG2 Multi-Agent Code Execution with CyberSandbox
+
+Inherited from upstream agent-infra/sandbox; API-compatible with
+ghcr.io/prowlrbot/cybersandbox:latest.
 
 A multi-agent system where a Coder agent writes and executes Python code inside
 a sandboxed environment, and a Reviewer agent validates results. All code runs

--- a/examples/langgraph-deepagents-integration/README.md
+++ b/examples/langgraph-deepagents-integration/README.md
@@ -1,6 +1,8 @@
-# aio-deepagents
+# LangGraph + DeepAgents (integration example)
 
-A LangGraph-based deep agent implementation that uses AIO Sandbox as a native DeepAgents sandbox backend, implementing the `BaseSandbox` protocol (`execute`, `upload_files`, `download_files`).
+> **Inherited from upstream [agent-infra/sandbox](https://github.com/agent-infra/sandbox).** This example still targets the upstream image and wording; CyberSandbox is API-compatible and works as a drop-in replacement by substituting `ghcr.io/prowlrbot/cybersandbox:latest`. The canonical CyberSandbox SDK surface is documented in [`sdk/python/README.md`](../../sdk/python/README.md).
+
+A LangGraph-based deep agent implementation that uses the sandbox as a native DeepAgents backend, implementing the `BaseSandbox` protocol (`execute`, `upload_files`, `download_files`).
 
 ## Features
 

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agent-infra/sandbox",
   "version": "1.0.13",
-  "description": "Node.js SDK for AIO Sandbox integration providing tools and interfaces",
+  "description": "Node.js SDK for the CyberSandbox HTTP API — shell, file, code, browser, Jupyter, Node.js, MCP, skills, and cloud provider operations.",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.mjs",
   "types": "./dist/types/index.d.ts",


### PR DESCRIPTION
## Summary

Four user-facing spots still advertised the upstream brand. Fixed with minimal diff, no contract changes.

- \`sdk/js/package.json\` description → \"CyberSandbox HTTP API\"
- \`cybersandbox/SECURITY.md\` → reword the upstream-scope line as a fork clarification (still points users at agent-infra for upstream runtime vulns)
- \`examples/langgraph-deepagents-integration/README.md\` → inherited-from-upstream banner, pointing readers at the canonical CyberSandbox SDK docs
- \`examples/ag2-integration/main.py\` → inherited-from-upstream banner in the module docstring

## Intentionally not in this PR

- **\`sdk/js/package.json\` \`name: @agent-infra/sandbox\`** — renaming breaks every npm consumer. Needs its own PR with a migration guide and a deprecated placeholder on the old name.
- **\`UPSTREAM_README.md\`** — explicitly preserved upstream attribution, per root README.
- **\`AIO_SKILLS_PATH\` env var** in \`docker-compose.yaml\` — upstream runtime contract, not branding.
- **\`evaluation/\`** — upstream benchmark harness, internal test artifact.

## Test plan

- [x] \`grep -n 'AIO Sandbox'\` returns only the files explicitly left alone above
- [x] JS SDK \`pnpm install\` still resolves (no \`name\` change)
- [ ] Reviewer: confirm no other user-facing docs slipped through