### PR TITLE
feat(plugins): malware triage installer + plugins showcase page

### DIFF
--- a/cybersandbox/scripts/install-malware-tools.sh
+++ b/cybersandbox/scripts/install-malware-tools.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# install-malware-tools.sh — adds malware triage / reverse-engineering tools
+# to a running CyberSandbox container.
+#
+# Safe to re-run; each step is idempotent.
+#
+# Usage (host):
+#   docker exec -it cybersandbox bash /opt/cybersandbox/scripts/install-malware-tools.sh
+#
+# Or (inside container):
+#   sudo bash install-malware-tools.sh
+#
+# What you get:
+#   engines:  yara, yara-python, capa, oletools, pefile, lief,
+#             exiftool, rizin, upx, dnsrecon
+#   rules:    (install via `csbx install yara-rules-community`,
+#              `csbx install signature-base`, `csbx install capa-rules`,
+#              `csbx install sigma` — see plugins guide on the website)
+
+set -euo pipefail
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
+CYAN='\033[0;36m'; NC='\033[0m'
+info()  { echo -e "${CYAN}[+]${NC} $*"; }
+ok()    { echo -e "${GREEN}[✓]${NC} $*"; }
+warn()  { echo -e "${YELLOW}[!]${NC} $*"; }
+err()   { echo -e "${RED}[x]${NC} $*" >&2; }
+
+SUDO=""
+if [ "$(id -u)" -ne 0 ]; then
+  if command -v sudo >/dev/null 2>&1; then
+    SUDO="sudo"
+  else
+    err "Not root and sudo unavailable. Re-run as root."
+    exit 1
+  fi
+fi
+
+# ── Detect package manager ───────────────────────────────────
+if command -v apt-get >/dev/null 2>&1; then
+  PKG="apt"
+elif command -v dnf >/dev/null 2>&1; then
+  PKG="dnf"
+else
+  err "Unsupported distro (need apt or dnf)."
+  exit 1
+fi
+
+# ── Apt/dnf packages ─────────────────────────────────────────
+APT_PACKAGES=(
+  yara
+  libyara-dev
+  python3-yara
+  libimage-exiftool-perl
+  upx-ucl
+  rizin
+  dnsrecon
+  libmagic1
+)
+
+DNF_PACKAGES=(
+  yara
+  yara-devel
+  perl-Image-ExifTool
+  upx
+  rizin
+  dnsrecon
+  file-libs
+)
+
+install_apt() {
+  info "Updating apt index"
+  $SUDO apt-get update -qq
+  info "Installing apt packages: ${APT_PACKAGES[*]}"
+  DEBIAN_FRONTEND=noninteractive $SUDO apt-get install -y --no-install-recommends "${APT_PACKAGES[@]}"
+}
+
+install_dnf() {
+  info "Installing dnf packages: ${DNF_PACKAGES[*]}"
+  $SUDO dnf install -y "${DNF_PACKAGES[@]}"
+}
+
+# ── Python tools ─────────────────────────────────────────────
+PIP_PACKAGES=(
+  yara-python
+  flare-capa
+  oletools
+  pefile
+  lief
+  python-magic
+  dnspython
+)
+
+install_pip() {
+  info "Installing Python packages: ${PIP_PACKAGES[*]}"
+  # Prefer pipx on PEP-668 distros; fall back to pip with --break-system-packages
+  # only inside the sandbox (image is disposable).
+  if command -v pipx >/dev/null 2>&1; then
+    for pkg in "${PIP_PACKAGES[@]}"; do
+      pipx install --force "$pkg" 2>/dev/null || pip install --user "$pkg" --break-system-packages 2>/dev/null || \
+        pip install --user "$pkg"
+    done
+  else
+    pip install --user "${PIP_PACKAGES[@]}" --break-system-packages 2>/dev/null || \
+      pip install --user "${PIP_PACKAGES[@]}"
+  fi
+}
+
+# ── Smoke test ───────────────────────────────────────────────
+verify() {
+  info "Verifying installs"
+  local failed=0
+  for bin in yara capa olevba pefile exiftool rizin upx; do
+    if command -v "$bin" >/dev/null 2>&1 || python3 -c "import $bin" >/dev/null 2>&1; then
+      ok "  $bin"
+    else
+      warn "  $bin — not found on PATH (may be a Python-only module)"
+      failed=$((failed + 1))
+    fi
+  done
+
+  # Python import checks for library-only packages
+  for mod in yara lief oletools.olevba; do
+    if python3 -c "import $mod" >/dev/null 2>&1; then
+      ok "  python: $mod"
+    else
+      warn "  python: $mod (import failed)"
+      failed=$((failed + 1))
+    fi
+  done
+
+  [ "$failed" -eq 0 ]
+}
+
+# ── Main ─────────────────────────────────────────────────────
+case "$PKG" in
+  apt) install_apt ;;
+  dnf) install_dnf ;;
+esac
+
+install_pip
+
+if verify; then
+  ok "Malware tools installed"
+  echo
+  info "Next: install rule sets via csbx"
+  echo "    csbx install yara-rules-community"
+  echo "    csbx install signature-base"
+  echo "    csbx install capa-rules"
+  echo "    csbx install sigma"
+else
+  warn "Some tools did not verify cleanly. Re-run after investigating, or"
+  warn "check container logs for package conflicts."
+  exit 1
+fi

--- a/cybersandbox/scripts/install-malware-tools.sh
+++ b/cybersandbox/scripts/install-malware-tools.sh
@@ -81,46 +81,63 @@ install_dnf() {
 }
 
 # ── Python tools ─────────────────────────────────────────────
-PIP_PACKAGES=(
-  yara-python
+# Split by role: apps expose CLI entry points (pipx-suitable), libs are
+# import-only and must land somewhere system python3 can see them.
+PIP_APPS=(
   flare-capa
   oletools
+)
+
+PIP_LIBS=(
+  yara-python
   pefile
   lief
   python-magic
   dnspython
 )
 
+pip_install_lib() {
+  local pkg="$1"
+  # Try --break-system-packages first (PEP 668 distros); fall back for older pip.
+  pip install --user --break-system-packages "$pkg" 2>/dev/null \
+    || pip install --user "$pkg"
+}
+
 install_pip() {
-  info "Installing Python packages: ${PIP_PACKAGES[*]}"
-  # Prefer pipx on PEP-668 distros; fall back to pip with --break-system-packages
-  # only inside the sandbox (image is disposable).
+  info "Installing Python apps via pipx: ${PIP_APPS[*]}"
   if command -v pipx >/dev/null 2>&1; then
-    for pkg in "${PIP_PACKAGES[@]}"; do
-      pipx install --force "$pkg" 2>/dev/null || pip install --user "$pkg" --break-system-packages 2>/dev/null || \
-        pip install --user "$pkg"
+    for pkg in "${PIP_APPS[@]}"; do
+      pipx install --force "$pkg" || pip_install_lib "$pkg"
     done
   else
-    pip install --user "${PIP_PACKAGES[@]}" --break-system-packages 2>/dev/null || \
-      pip install --user "${PIP_PACKAGES[@]}"
+    for pkg in "${PIP_APPS[@]}"; do
+      pip_install_lib "$pkg"
+    done
   fi
+
+  info "Installing Python libraries via pip: ${PIP_LIBS[*]}"
+  # pipx cannot install libraries into the system interpreter — always use pip.
+  for pkg in "${PIP_LIBS[@]}"; do
+    pip_install_lib "$pkg"
+  done
 }
 
 # ── Smoke test ───────────────────────────────────────────────
 verify() {
   info "Verifying installs"
   local failed=0
-  for bin in yara capa olevba pefile exiftool rizin upx; do
-    if command -v "$bin" >/dev/null 2>&1 || python3 -c "import $bin" >/dev/null 2>&1; then
+  # CLI tools — must be on PATH
+  for bin in yara capa olevba exiftool rizin upx; do
+    if command -v "$bin" >/dev/null 2>&1; then
       ok "  $bin"
     else
-      warn "  $bin — not found on PATH (may be a Python-only module)"
+      warn "  $bin — not found on PATH"
       failed=$((failed + 1))
     fi
   done
 
-  # Python import checks for library-only packages
-  for mod in yara lief oletools.olevba; do
+  # Python library imports — must be importable from system python3
+  for mod in yara lief oletools.olevba pefile magic dns.resolver; do
     if python3 -c "import $mod" >/dev/null 2>&1; then
       ok "  python: $mod"
     else

--- a/website/docs/en/guide/_meta.json
+++ b/website/docs/en/guide/_meta.json
@@ -8,5 +8,10 @@
     "type": "dir",
     "label": "Features",
     "name": "basic"
+  },
+  {
+    "type": "file",
+    "label": "Plugins",
+    "name": "plugins"
   }
 ]

--- a/website/docs/en/guide/plugins.md
+++ b/website/docs/en/guide/plugins.md
@@ -1,0 +1,149 @@
+# Plugins & Extensions
+
+CyberSandbox ships with a minimal base image. Everything else — wordlists, nuclei templates, YARA rules, malware triage tools, editor themes — installs on demand through **csbx**, the built-in plugin manager.
+
+This keeps the image small, builds reproducible, and lets you pull only what a given job actually needs.
+
+## How csbx Works
+
+Every plugin is declared in a public registry (`ProwlrBot/csbx-registry`) as a typed entry:
+
+- `wordlist` — SecLists, PayloadsAllTheThings, FuzzDB, …
+- `nuclei-templates` — vendor / community template packs
+- `config` — prebuilt tool configs (nuclei, httpx, katana, …)
+- `theme` — editor and terminal themes
+- `yara-rules` — malware detection rule sets
+- `sigma` — detection rules for logs and EDR
+
+Install is always the same shape:
+
+```bash
+csbx install <plugin-name>
+csbx list            # what's installed
+csbx update <name>   # refresh from upstream
+csbx remove <name>
+```
+
+Plugins land under `/opt/cybersandbox/plugins/<name>/` inside the container.
+
+## Malware Triage Tools
+
+A first-class install script is bundled with the image:
+
+```bash
+docker exec -it cybersandbox \
+  bash /opt/cybersandbox/scripts/install-malware-tools.sh
+```
+
+What you get:
+
+| Tool | Purpose |
+| --- | --- |
+| `yara` + `yara-python` | Signature-based malware detection |
+| `capa` (flare-capa) | Capability detection for PE / ELF / .NET |
+| `oletools` | OLE / Office document triage (olevba, oleid, rtfobj) |
+| `pefile`, `lief` | Static PE / ELF parsing from Python |
+| `exiftool` | Metadata extraction from any binary / document |
+| `rizin` | Reverse-engineering framework |
+| `upx` | Unpack UPX-packed binaries |
+| `dnsrecon`, `dnspython` | DNS triage for C2 / IOC pivots |
+
+After the tools are installed, pull rule sets via csbx:
+
+```bash
+csbx install yara-rules-community   # YARA-Rules/rules
+csbx install signature-base          # Neo23x0/signature-base (APT, webshells, hack tools)
+csbx install capa-rules              # mandiant/capa-rules
+csbx install sigma                   # SigmaHQ/sigma
+csbx install misp-warninglists       # MISP/misp-warninglists (FP reduction)
+```
+
+Typical triage session:
+
+```bash
+# Hash + metadata
+sha256sum sample.exe
+exiftool sample.exe
+
+# Static capability extraction
+capa sample.exe
+
+# Rule scan
+yara -r /opt/cybersandbox/plugins/yara-rules-community/rules sample.exe
+yara -r /opt/cybersandbox/plugins/signature-base/yara sample.exe
+
+# Office document triage
+olevba suspicious.docm
+oleid suspicious.docm
+
+# Unpack + disassemble
+upx -d packed.exe -o unpacked.exe
+rizin -A unpacked.exe
+```
+
+## Wordlists
+
+```bash
+csbx install seclists               # danielmiessler/SecLists
+csbx install payloadsallthethings   # swisskyrepo/PayloadsAllTheThings
+csbx install fuzzdb                 # fuzzdb-project/fuzzdb
+csbx install assetnote-wordlists    # assetnote/commonspeak2-wordlists
+```
+
+Installed at `/opt/cybersandbox/plugins/<name>/` — reference them directly from ffuf, feroxbuster, dirsearch, etc.
+
+## Nuclei Templates
+
+```bash
+csbx install nuclei-templates         # projectdiscovery/nuclei-templates (official)
+csbx install nuclei-templates-geeknik # geeknik/the-nuclei-templates
+csbx install nuclei-fuzzing-templates # projectdiscovery/fuzzing-templates
+```
+
+Point nuclei at any installed pack:
+
+```bash
+nuclei -t /opt/cybersandbox/plugins/nuclei-templates/ -u https://target
+```
+
+## Configs & Themes
+
+```bash
+csbx install nuclei-config    # tuned severity + rate-limit defaults
+csbx install httpx-config     # TLS + retry profile
+csbx install theme-dracula    # terminal + code-server theme
+csbx install theme-tokyonight
+```
+
+## Contributing a Plugin
+
+Plugins are just YAML entries. Open a PR against [`ProwlrBot/csbx-registry`](https://github.com/ProwlrBot/csbx-registry) with an entry like:
+
+```yaml
+plugins:
+  - name: your-plugin-name
+    type: wordlist               # or yara-rules, nuclei-templates, config, theme, sigma
+    description: One-line description.
+    url: https://github.com/you/your-repo
+    license: MIT
+    install:
+      method: git                # git | tarball | pip
+      ref: main                  # optional pinned ref
+```
+
+Rules:
+
+- Alphabetical order within each `type` block.
+- License must be OSS-compatible (MIT / Apache-2.0 / BSD / GPL variants).
+- No binaries in the registry itself — only pointers to upstream sources.
+- Rule-set plugins (`yara-rules`, `sigma`) should have an upstream that is actively maintained.
+
+See [`csbx-registry/CONTRIBUTING.md`](https://github.com/ProwlrBot/csbx-registry/blob/main/CONTRIBUTING.md) for the full contribution flow.
+
+## Roadmap
+
+- `sigma` → `sigma-cli` + native conversion to Splunk / Elastic / Sentinel
+- `opencti-client` plugin — push YARA / capa findings straight into an OpenCTI instance as STIX 2.1 observables
+- `caido-plugins` — prebuilt Caido plugin bundles for request modification and triage
+
+Watch the [CyberSandbox changelog](https://github.com/ProwlrBot/CyberBox/releases) for new plugins as they land.

--- a/website/docs/zh/guide/_meta.json
+++ b/website/docs/zh/guide/_meta.json
@@ -8,5 +8,10 @@
     "type": "dir",
     "label": "特性",
     "name": "basic"
+  },
+  {
+    "type": "file",
+    "label": "插件",
+    "name": "plugins"
   }
 ]

--- a/website/docs/zh/guide/plugins.md
+++ b/website/docs/zh/guide/plugins.md
@@ -1,0 +1,130 @@
+# 插件与扩展
+
+CyberSandbox 的基础镜像保持最小化。字典、nuclei 模板、YARA 规则、恶意软件分析工具、编辑器主题等一切按需通过内置插件管理器 **csbx** 安装。
+
+这样镜像体积可控、构建可复现,每个任务只拉取真正需要的内容。
+
+## csbx 工作原理
+
+所有插件都登记在公开注册表(`ProwlrBot/csbx-registry`)中,按类型标注:
+
+- `wordlist` — SecLists、PayloadsAllTheThings、FuzzDB 等
+- `nuclei-templates` — 官方/社区模板包
+- `config` — 预制工具配置(nuclei、httpx、katana 等)
+- `theme` — 编辑器与终端主题
+- `yara-rules` — 恶意软件检测规则集
+- `sigma` — 日志与 EDR 检测规则
+
+安装命令统一为:
+
+```bash
+csbx install <plugin-name>
+csbx list            # 已安装插件
+csbx update <name>   # 从上游刷新
+csbx remove <name>
+```
+
+插件安装到容器内 `/opt/cybersandbox/plugins/<name>/`。
+
+## 恶意软件分析工具
+
+镜像内置一个一键安装脚本:
+
+```bash
+docker exec -it cybersandbox \
+  bash /opt/cybersandbox/scripts/install-malware-tools.sh
+```
+
+包含:
+
+| 工具 | 用途 |
+| --- | --- |
+| `yara` + `yara-python` | 基于签名的恶意软件检测 |
+| `capa` (flare-capa) | PE / ELF / .NET 能力识别 |
+| `oletools` | Office 文档分析(olevba、oleid、rtfobj) |
+| `pefile`、`lief` | Python 环境下的 PE / ELF 静态解析 |
+| `exiftool` | 提取任意二进制/文档的元数据 |
+| `rizin` | 逆向工程框架 |
+| `upx` | 解压 UPX 加壳程序 |
+| `dnsrecon`、`dnspython` | 针对 C2 / IOC 的 DNS 分析 |
+
+工具安装后,通过 csbx 拉取规则集:
+
+```bash
+csbx install yara-rules-community
+csbx install signature-base
+csbx install capa-rules
+csbx install sigma
+csbx install misp-warninglists
+```
+
+典型分析流程:
+
+```bash
+sha256sum sample.exe
+exiftool sample.exe
+capa sample.exe
+yara -r /opt/cybersandbox/plugins/yara-rules-community/rules sample.exe
+olevba suspicious.docm
+upx -d packed.exe -o unpacked.exe
+rizin -A unpacked.exe
+```
+
+## 字典
+
+```bash
+csbx install seclists
+csbx install payloadsallthethings
+csbx install fuzzdb
+csbx install assetnote-wordlists
+```
+
+## Nuclei 模板
+
+```bash
+csbx install nuclei-templates
+csbx install nuclei-templates-geeknik
+csbx install nuclei-fuzzing-templates
+```
+
+## 配置与主题
+
+```bash
+csbx install nuclei-config
+csbx install httpx-config
+csbx install theme-dracula
+csbx install theme-tokyonight
+```
+
+## 贡献插件
+
+插件本身是一段 YAML。向 [`ProwlrBot/csbx-registry`](https://github.com/ProwlrBot/csbx-registry) 提交 PR 即可,格式:
+
+```yaml
+plugins:
+  - name: your-plugin-name
+    type: wordlist
+    description: 一句话描述
+    url: https://github.com/you/your-repo
+    license: MIT
+    install:
+      method: git
+      ref: main
+```
+
+规则:
+
+- 在 `type` 分组内按字母排序
+- 许可证必须与 OSS 兼容(MIT / Apache-2.0 / BSD / GPL 系)
+- 注册表中不放二进制,只指向上游
+- 规则集类插件(`yara-rules`、`sigma`)必须对应积极维护的上游
+
+完整流程见 [`csbx-registry/CONTRIBUTING.md`](https://github.com/ProwlrBot/csbx-registry/blob/main/CONTRIBUTING.md)。
+
+## 路线图
+
+- `sigma` → 原生转换到 Splunk / Elastic / Sentinel
+- `opencti-client` 插件 — 将 YARA / capa 结果以 STIX 2.1 格式推送到 OpenCTI
+- `caido-plugins` — 预打包的 Caido 插件集合
+
+关注 [CyberSandbox changelog](https://github.com/ProwlrBot/CyberBox/releases) 获取新插件进展。


### PR DESCRIPTION
## What

- **`cybersandbox/scripts/install-malware-tools.sh`** — idempotent, dual-distro (apt / dnf) installer that drops a working malware triage stack into a running container:
  - APT/DNF: `yara`, `yara-devel`/`libyara-dev`, `python3-yara`, `exiftool`, `upx`, `rizin`, `dnsrecon`, `libmagic`
  - pip: `yara-python`, `flare-capa`, `oletools`, `pefile`, `lief`, `python-magic`, `dnspython`
  - Handles PEP 668 via `pipx` fallback + `--break-system-packages` (sandbox is disposable).
  - Smoke-tests every install and prints the csbx commands needed to pull rule sets.

- **`website/docs/{en,zh}/guide/plugins.md`** — new "Plugins" section of the docs site:
  - Explains the csbx plugin model and install flow.
  - Documents the malware tooling bundle with a realistic triage session.
  - Lists wordlist, nuclei-template, config, and theme plugins.
  - Shows the YAML registry entry format so third parties can contribute.
  - Roadmap: sigma-cli conversion, OpenCTI STIX 2.1 push plugin, Caido plugin bundles.

- **`_meta.json` (en + zh)** — adds the new "Plugins" / "插件" entry to the guide nav.

## Why

The image itself stays lean; rule sets and wordlists can be gigabytes. Pushing this to csbx keeps the base image small, makes what's installed explicit, and gives the community a clean way to contribute new plugins without touching the image.

## Test plan

- [ ] `bash cybersandbox/scripts/install-malware-tools.sh` inside a fresh container — all smoke tests pass
- [ ] `yara --version`, `capa -h`, `olevba -h`, `rizin -v`, `exiftool -ver`, `upx --version` all resolve
- [ ] `python3 -c 'import yara, lief, oletools.olevba, pefile'` — no import errors
- [ ] `rspress dev` renders the new Plugins page in both `/guide/plugins` and `/zh/guide/plugins`
- [ ] Nav shows "Plugins" between Features and the next section

## Follow-ups

- Separate PR to `ProwlrBot/csbx-registry` adding the five rule-set plugin entries (`yara-rules-community`, `signature-base`, `capa-rules`, `sigma`, `misp-warninglists`)
- Issue #17 (drop `USER 1000` from `Dockerfile`) still open

🤖 Generated with [Claude Code](https://claude.com/claude-code)