### PR TITLE
ci: add ghactor lint + doctor gate for workflow changes

### DIFF
--- a/.github/workflows/ghactor.yml
+++ b/.github/workflows/ghactor.yml
@@ -1,0 +1,69 @@
+name: ghactor
+
+# Gates every change to GitHub Actions workflows through ghactor's
+# security-first lint + supply-chain audit. Fails CI on any issue so
+# workflow drift is caught at PR time rather than after merge.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+  schedule:
+    # Weekly sweep so upstream action releases surface as a PR-able delta
+    # even when no workflow file changes.
+    - cron: '17 5 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: Lint + doctor
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: '1.23'
+          cache: false
+
+      - name: Install ghactor
+        env:
+          # Required because kdairatchi/ghactor is a private module until
+          # the user flips it public. GOPRIVATE keeps go from hitting the
+          # public proxy and GONOSUMCHECK skips sum.golang.org.
+          GOPRIVATE: github.com/kdairatchi/*
+          GONOSUMCHECK: 'off'
+          GH_TOKEN: ${{ secrets.GHACTOR_INSTALL_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          # Tell go to authenticate via gh to github.com for private repos.
+          git config --global url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
+          go install github.com/kdairatchi/ghactor/cmd/ghactor@v0.2.0
+
+      - name: ghactor doctor
+        run: ghactor doctor
+
+      - name: ghactor lint
+        run: ghactor lint
+
+      - name: ghactor update (report only)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ghactor update --changelog /tmp/ghactor-updates.md || true
+          if [ -s /tmp/ghactor-updates.md ]; then
+            echo "## Upstream action updates available" >> "$GITHUB_STEP_SUMMARY"
+            cat /tmp/ghactor-updates.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "All actions current or unresolvable." >> "$GITHUB_STEP_SUMMARY"
+          fi


### PR DESCRIPTION
## What

Adds \`.github/workflows/ghactor.yml\` — a CI job that runs [\`ghactor\`](https://github.com/kdairatchi/ghactor) against every change to \`.github/workflows/**\`:

- \`ghactor doctor\` — repo-wide workflow health report, fails on score regression
- \`ghactor lint\` — actionlint + ghactor security rules
- \`ghactor update\` — reports available upstream action bumps as a step summary (report-only, does not fail)

Also runs on a weekly cron (Mon 05:17 UTC) so upstream action releases surface as a PR-able delta even when no workflow file changes.

## Why

Workflows drift. Unpinned SHAs, missing timeouts, over-broad permissions, stale actions — all become supply-chain blind spots if caught only at human review. ghactor encodes these as hard rules and runs them at PR time.

Current main is \`100/100\` via \`ghactor doctor\` — this wiring keeps it there.

## Access note

Installs from the (currently private) \`kdairatchi/ghactor\` module. The job supports either:

- A \`GHACTOR_INSTALL_TOKEN\` repo secret (PAT with read access), or
- Fallback to \`GITHUB_TOKEN\` — which works as soon as the module is flipped public.

Recommend flipping \`kdairatchi/ghactor\` public and removing the fallback comment, or provisioning the secret.

## Test plan

- [ ] First run (this PR) must pass
- [ ] Intentional regression on a branch (unpinned action / missing timeout) must fail the job
- [ ] Weekly cron fires and reports upstream action updates in step summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)