### PR TITLE
feat(cli): invoke-ollama port (spec 018, Phase 2)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -10,7 +10,7 @@ files becoming thin shims once a Go implementation exists.
 | Subcommand | Status | Notes |
 |------------|--------|-------|
 | `cyberbox invoke-claude` | ✅ Ported (Phase 1) | Behavioral parity with `harbinger/bin/invoke-claude` |
-| `cyberbox invoke-ollama` | 🟡 Stub | Prints redirect to bash file |
+| `cyberbox invoke-ollama` | ✅ Ported (Phase 2) | Behavioral parity with `harbinger/bin/invoke-ollama`; supports `-m/-s/-j/-r/-l` flags + OLLAMA_HOST/OLLAMA_MODEL env precedence |
 | `cyberbox csbx` | 🟡 Stub | Prints redirect to bash file |
 | `cyberbox harbinger` | 🟡 Stub | Prints redirect to bash file |
 
@@ -37,22 +37,28 @@ make cross        # smoke-build for all 5 release targets
 make install      # go install into $GOPATH/bin
 ```
 
-## Use it (Phase 1)
+## Use it (Phases 1 + 2)
 
 ```bash
+# invoke-claude (Phase 1) — needs ANTHROPIC_API_KEY or CLAUDE_API_KEY
 export ANTHROPIC_API_KEY=sk-ant-...
-
-# Args + stdin both supported, same as bash:
 ./dist/cyberbox invoke-claude "explain this vuln"
 cat finding.txt | ./dist/cyberbox invoke-claude "summarise"
 ./dist/cyberbox invoke-claude -m opus -s "You are a pentest expert" "review this"
 curl -s target.com | ./dist/cyberbox invoke-claude -j "extract endpoints"
+
+# invoke-ollama (Phase 2) — needs a local Ollama daemon (`ollama serve`)
+./dist/cyberbox invoke-ollama "explain this HTTP response"
+cat response.txt | ./dist/cyberbox invoke-ollama "find security issues"
+./dist/cyberbox invoke-ollama -m deepseek-r1 "complex analysis"
+./dist/cyberbox invoke-ollama -l                            # list installed models
+nuclei -jsonl -u target.com | ./dist/cyberbox invoke-ollama "triage these findings"
 ```
 
-Flags match the bash invoke-claude exactly: `-m/--model`, `-s/--system`,
-`-t/--tokens`, `-j/--json`, `-r/--raw`, `-h/--help`. Model aliases
-(`sonnet`/`opus`/`haiku`) and the `ANTHROPIC_API_KEY`/`CLAUDE_API_KEY`
-env-var precedence are preserved.
+Flag parity with the bash scripts:
+
+- **invoke-claude**: `-m/--model`, `-s/--system`, `-t/--tokens`, `-j/--json`, `-r/--raw`, `-h/--help`. Model aliases (`sonnet`/`opus`/`haiku`) + `ANTHROPIC_API_KEY`/`CLAUDE_API_KEY` env-var precedence preserved.
+- **invoke-ollama**: `-m/--model`, `-s/--system`, `-j/--json`, `-r/--raw`, `-l/--list`, `-h/--help`. `OLLAMA_HOST`/`OLLAMA_MODEL` env-var precedence preserved (flag > env > default `llama3.1`).
 
 ## Migration plan
 
@@ -90,12 +96,17 @@ cli/
 ├── main.go                          # tiny entrypoint
 ├── cmd/
 │   ├── root.go                      # cobra root + version
-│   ├── invoke_claude.go             # the only fully ported command
+│   ├── invoke_claude.go             # Phase 1: Anthropic Messages API
 │   ├── invoke_claude_test.go        # table-driven tests via httptest
-│   └── stubs.go                     # csbx/harbinger/invoke-ollama redirect stubs
+│   ├── invoke_ollama.go             # Phase 2: local Ollama daemon
+│   ├── invoke_ollama_test.go        # table-driven tests via httptest
+│   └── stubs.go                     # csbx/harbinger redirect stubs (Phase 3+)
 ├── internal/
-│   └── anthropic/
-│       ├── client.go                # minimal Messages API client
+│   ├── anthropic/
+│   │   ├── client.go                # minimal Messages API client
+│   │   └── client_test.go
+│   └── ollama/
+│       ├── client.go                # minimal /api/generate + /api/tags client
 │       └── client_test.go
 ├── Makefile
 ├── .goreleaser.yaml                 # cosign-signed, SBOM-attached release config

--- a/cli/cmd/invoke_ollama.go
+++ b/cli/cmd/invoke_ollama.go
@@ -1,0 +1,176 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/ProwlrBot/CyberBox/cli/internal/ollama"
+)
+
+// invokeOllamaOpts mirrors the bash invoke-ollama flag surface. The
+// default model and host are resolved at run-time so env-var changes
+// after package init still take effect.
+type invokeOllamaOpts struct {
+	model     string
+	system    string
+	jsonMode  bool
+	rawOutput bool
+	listMode  bool
+}
+
+func newInvokeOllamaCmd() *cobra.Command {
+	opts := &invokeOllamaOpts{}
+
+	cmd := &cobra.Command{
+		Use:   "invoke-ollama [prompt]...",
+		Short: "Send prompts to a local Ollama instance",
+		Long: `invoke-ollama — Ollama from the terminal (local, private, free).
+
+Reads stdin if connected to a pipe and concatenates it with any prompt args.
+Behavioral parity with the legacy bash invoke-ollama script: same flag surface,
+same OLLAMA_HOST/OLLAMA_MODEL env-var precedence, same TTY-aware stderr usage
+footer.`,
+		Example: `  cyberbox invoke-ollama "explain this HTTP response"
+  cat response.txt | cyberbox invoke-ollama "find security issues"
+  cyberbox invoke-ollama -m deepseek-r1 "complex analysis"
+  cyberbox invoke-ollama -l
+  nuclei -jsonl -u target.com | cyberbox invoke-ollama "triage these findings"`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runInvokeOllama(cmd.Context(), opts, args, os.Stdin, os.Stdout, os.Stderr)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.model, "model", "m", "",
+		"Model name (default: $OLLAMA_MODEL or "+ollama.DefaultModel+")")
+	cmd.Flags().StringVarP(&opts.system, "system", "s", "",
+		"System prompt")
+	cmd.Flags().BoolVarP(&opts.jsonMode, "json", "j", false,
+		"Request JSON-format output (Ollama format=\"json\")")
+	cmd.Flags().BoolVarP(&opts.rawOutput, "raw", "r", false,
+		"Raw output: suppress 'thinking…' and token/duration footer on stderr")
+	cmd.Flags().BoolVarP(&opts.listMode, "list", "l", false,
+		"List models available on the daemon and exit")
+
+	return cmd
+}
+
+// runInvokeOllama is the testable core. The cobra wrapper passes real
+// os.Std* streams; tests pass bytes.Buffer / bytes.Reader.
+func runInvokeOllama(
+	ctx context.Context,
+	opts *invokeOllamaOpts,
+	args []string,
+	stdin io.Reader,
+	stdout, stderr io.Writer,
+) error {
+	host := envOrDefault("OLLAMA_HOST", ollama.DefaultEndpoint)
+	client := ollama.New(ollama.Config{Endpoint: host})
+
+	// --list short-circuits everything else; matches the bash script.
+	if opts.listMode {
+		return runOllamaList(ctx, client, host, stdout, stderr)
+	}
+
+	model := firstNonEmpty(opts.model, os.Getenv("OLLAMA_MODEL"), ollama.DefaultModel)
+
+	// Connection check before we spend time building the prompt — same
+	// UX as the bash script's curl preflight. Distinguishes "daemon
+	// down" (clear hint) from "request failed mid-flight" (generic err).
+	if err := client.Ping(ctx); err != nil {
+		fmt.Fprintf(stderr, "Error: Ollama not running at %s\n", host)
+		fmt.Fprintln(stderr, "  Start it: ollama serve")
+		fmt.Fprintln(stderr, "  Or set:   export OLLAMA_HOST=http://your-host:11434")
+		return fmt.Errorf("ollama unreachable at %s: %w", host, err)
+	}
+
+	prompt := buildPrompt(args, stdin)
+	if prompt == "" {
+		fmt.Fprintln(stderr, `Error: No prompt provided. Use: invoke-ollama "your prompt"`)
+		return errors.New("no prompt")
+	}
+
+	format := ""
+	if opts.jsonMode {
+		format = "json"
+	}
+
+	if !opts.rawOutput && isTerminal(stderr) {
+		dim, reset := colorCodes(stderr)
+		fmt.Fprintf(stderr, "%s[ollama:%s] thinking...%s\n", dim, model, reset)
+	}
+
+	resp, err := client.Generate(ctx, ollama.Request{
+		Model:  model,
+		Prompt: prompt,
+		System: opts.system,
+		Format: format,
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "Error: %s\n", err)
+		return err
+	}
+
+	if resp.Response == "" {
+		fmt.Fprintln(stderr, "Error: empty response from ollama")
+		return errors.New("empty response")
+	}
+
+	fmt.Fprintln(stdout, resp.Response)
+	if !opts.rawOutput {
+		dim, reset := colorCodes(stderr)
+		fmt.Fprintf(stderr, "\n%s[tokens: %s | %.1fs | model: %s]%s\n",
+			dim,
+			ollamaUsageStr(resp.EvalCount),
+			resp.DurationSeconds(),
+			model, reset,
+		)
+	}
+	return nil
+}
+
+// runOllamaList is the --list path. Aligned columns via text/tabwriter
+// so readability matches the bash version's `column -t -s $'\t'`.
+func runOllamaList(ctx context.Context, client *ollama.Client, host string, stdout, stderr io.Writer) error {
+	tags, err := client.ListModels(ctx)
+	if err != nil {
+		fmt.Fprintf(stderr, "Error: Ollama not running at %s\n", host)
+		fmt.Fprintln(stderr, "  Start it: ollama serve")
+		return err
+	}
+	if len(tags.Models) == 0 {
+		fmt.Fprintln(stderr, "No models installed. Pull one: ollama pull llama3.1")
+		return nil
+	}
+
+	tw := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
+	for _, m := range tags.Models {
+		// Bash script formatted size as GB with 2dp; replicate that.
+		sizeGB := float64(m.Size) / (1024 * 1024 * 1024)
+		params := m.Details.ParameterSize
+		if params == "" {
+			params = "?"
+		}
+		fmt.Fprintf(tw, "%s\t%.2fGB\t%s\n", m.Name, sizeGB, params)
+	}
+	return tw.Flush()
+}
+
+// ollamaUsageStr — same shape as usageStr from invoke_claude.go, kept
+// separate to avoid coupling the two ports' formatting accidentally.
+func ollamaUsageStr(n int) string {
+	if n <= 0 {
+		return "?"
+	}
+	return strconv.Itoa(n)
+}
+
+// Compile-time guard: keep io.Writer reachable even if the file shrinks.
+var _ io.Writer = (*strings.Builder)(nil)

--- a/cli/cmd/invoke_ollama_test.go
+++ b/cli/cmd/invoke_ollama_test.go
@@ -1,0 +1,289 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ProwlrBot/CyberBox/cli/internal/ollama"
+)
+
+// newFakeOllamaAPI mirrors newFakeAPI in invoke_claude_test.go but for
+// Ollama's two endpoints. capture (if non-nil) records the most recent
+// /api/generate request payload.
+func newFakeOllamaAPI(t *testing.T, capture *ollama.Request, genReply ollama.Response, tagsReply ollama.TagsResponse) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc(ollama.GeneratePath, func(w http.ResponseWriter, r *http.Request) {
+		if capture != nil {
+			_ = json.NewDecoder(r.Body).Decode(capture)
+		}
+		_ = json.NewEncoder(w).Encode(genReply)
+	})
+	mux.HandleFunc(ollama.TagsPath, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(tagsReply)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestInvokeOllamaHappyPath(t *testing.T) {
+	var captured ollama.Request
+	srv := newFakeOllamaAPI(t, &captured, ollama.Response{
+		Response:      "triage explanation",
+		Model:         "llama3.1",
+		TotalDuration: int64(3 * time.Second),
+		EvalCount:     128,
+		Done:          true,
+	}, ollama.TagsResponse{})
+	t.Setenv("OLLAMA_HOST", srv.URL)
+	t.Setenv("OLLAMA_MODEL", "")
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	err := runInvokeOllama(
+		context.Background(),
+		&invokeOllamaOpts{model: "deepseek-r1", rawOutput: true},
+		[]string{"triage", "this", "finding"},
+		strings.NewReader(""),
+		stdout, stderr,
+	)
+	if err != nil {
+		t.Fatalf("runInvokeOllama: %v", err)
+	}
+
+	if !strings.Contains(stdout.String(), "triage explanation") {
+		t.Errorf("stdout missing API text: %q", stdout.String())
+	}
+	if captured.Model != "deepseek-r1" {
+		t.Errorf("model = %q; want deepseek-r1 (flag took precedence)", captured.Model)
+	}
+	if captured.Stream {
+		t.Error("client must always send stream=false; got true")
+	}
+	if got := captured.Prompt; got != "triage this finding" {
+		t.Errorf("prompt = %q; want concatenated args", got)
+	}
+}
+
+func TestInvokeOllamaModelEnvFallback(t *testing.T) {
+	var captured ollama.Request
+	srv := newFakeOllamaAPI(t, &captured, ollama.Response{Response: "ok", Done: true}, ollama.TagsResponse{})
+	t.Setenv("OLLAMA_HOST", srv.URL)
+	t.Setenv("OLLAMA_MODEL", "deepseek-r1:7b")
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	err := runInvokeOllama(
+		context.Background(),
+		&invokeOllamaOpts{rawOutput: true}, // no -m flag
+		[]string{"hi"},
+		strings.NewReader(""),
+		stdout, stderr,
+	)
+	if err != nil {
+		t.Fatalf("runInvokeOllama: %v", err)
+	}
+	if captured.Model != "deepseek-r1:7b" {
+		t.Errorf("model = %q; want OLLAMA_MODEL value", captured.Model)
+	}
+}
+
+func TestInvokeOllamaModelDefaultsToLlama(t *testing.T) {
+	var captured ollama.Request
+	srv := newFakeOllamaAPI(t, &captured, ollama.Response{Response: "ok", Done: true}, ollama.TagsResponse{})
+	t.Setenv("OLLAMA_HOST", srv.URL)
+	t.Setenv("OLLAMA_MODEL", "")
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	err := runInvokeOllama(
+		context.Background(),
+		&invokeOllamaOpts{rawOutput: true},
+		[]string{"hi"},
+		strings.NewReader(""),
+		stdout, stderr,
+	)
+	if err != nil {
+		t.Fatalf("runInvokeOllama: %v", err)
+	}
+	if captured.Model != ollama.DefaultModel {
+		t.Errorf("model = %q; want default %q", captured.Model, ollama.DefaultModel)
+	}
+}
+
+func TestInvokeOllamaStdinConcatenated(t *testing.T) {
+	var captured ollama.Request
+	srv := newFakeOllamaAPI(t, &captured, ollama.Response{Response: "ok", Done: true}, ollama.TagsResponse{})
+	t.Setenv("OLLAMA_HOST", srv.URL)
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	err := runInvokeOllama(
+		context.Background(),
+		&invokeOllamaOpts{rawOutput: true},
+		[]string{"summarise"},
+		strings.NewReader("HTTP 200 OK\nbody contents...\n"),
+		stdout, stderr,
+	)
+	if err != nil {
+		t.Fatalf("runInvokeOllama: %v", err)
+	}
+	want := "summarise\n\nHTTP 200 OK\nbody contents..."
+	if got := captured.Prompt; got != want {
+		t.Errorf("prompt mismatch:\n  got:  %q\n  want: %q", got, want)
+	}
+}
+
+func TestInvokeOllamaJSONModeSetsFormat(t *testing.T) {
+	var captured ollama.Request
+	srv := newFakeOllamaAPI(t, &captured, ollama.Response{Response: `{"k":1}`, Done: true}, ollama.TagsResponse{})
+	t.Setenv("OLLAMA_HOST", srv.URL)
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	err := runInvokeOllama(
+		context.Background(),
+		&invokeOllamaOpts{jsonMode: true, rawOutput: true},
+		[]string{"extract endpoints"},
+		strings.NewReader(""),
+		stdout, stderr,
+	)
+	if err != nil {
+		t.Fatalf("runInvokeOllama: %v", err)
+	}
+	if captured.Format != "json" {
+		t.Errorf("Format = %q; want \"json\"", captured.Format)
+	}
+}
+
+func TestInvokeOllamaSystemPromptForwarded(t *testing.T) {
+	var captured ollama.Request
+	srv := newFakeOllamaAPI(t, &captured, ollama.Response{Response: "ok", Done: true}, ollama.TagsResponse{})
+	t.Setenv("OLLAMA_HOST", srv.URL)
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	err := runInvokeOllama(
+		context.Background(),
+		&invokeOllamaOpts{system: "You are a security analyst.", rawOutput: true},
+		[]string{"hi"},
+		strings.NewReader(""),
+		stdout, stderr,
+	)
+	if err != nil {
+		t.Fatalf("runInvokeOllama: %v", err)
+	}
+	if captured.System != "You are a security analyst." {
+		t.Errorf("System = %q; want forwarded value", captured.System)
+	}
+}
+
+func TestInvokeOllamaNoPrompt(t *testing.T) {
+	srv := newFakeOllamaAPI(t, nil, ollama.Response{}, ollama.TagsResponse{})
+	t.Setenv("OLLAMA_HOST", srv.URL)
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	err := runInvokeOllama(
+		context.Background(),
+		&invokeOllamaOpts{rawOutput: true},
+		nil,
+		strings.NewReader(""),
+		stdout, stderr,
+	)
+	if err == nil {
+		t.Fatal("expected error when no prompt provided")
+	}
+}
+
+func TestInvokeOllamaUnreachableDaemonError(t *testing.T) {
+	t.Setenv("OLLAMA_HOST", "http://127.0.0.1:1") // unroutable
+	t.Setenv("OLLAMA_MODEL", "")
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	err := runInvokeOllama(
+		context.Background(),
+		&invokeOllamaOpts{rawOutput: true},
+		[]string{"hi"},
+		strings.NewReader(""),
+		stdout, stderr,
+	)
+	if err == nil {
+		t.Fatal("expected error when daemon unreachable")
+	}
+	// The hint must be discoverable — bash version users grep for "ollama serve".
+	if !strings.Contains(stderr.String(), "ollama serve") {
+		t.Errorf("stderr should hint 'ollama serve'; got %q", stderr.String())
+	}
+}
+
+func TestInvokeOllamaAPIErrorPropagated(t *testing.T) {
+	srv := newFakeOllamaAPI(t, nil, ollama.Response{Error: "model 'x' not found"}, ollama.TagsResponse{})
+	t.Setenv("OLLAMA_HOST", srv.URL)
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	err := runInvokeOllama(
+		context.Background(),
+		&invokeOllamaOpts{model: "x", rawOutput: true},
+		[]string{"hi"},
+		strings.NewReader(""),
+		stdout, stderr,
+	)
+	if err == nil {
+		t.Fatal("expected error to surface")
+	}
+	if !strings.Contains(stderr.String(), "model 'x' not found") {
+		t.Errorf("stderr should include API error; got %q", stderr.String())
+	}
+}
+
+func TestInvokeOllamaListMode(t *testing.T) {
+	srv := newFakeOllamaAPI(t, nil, ollama.Response{}, ollama.TagsResponse{
+		Models: []ollama.ModelTag{
+			{Name: "llama3.1:latest", Size: 4_700_000_000, Details: ollama.ModelTagDetail{ParameterSize: "8.0B"}},
+			{Name: "deepseek-r1:7b", Size: 4_300_000_000, Details: ollama.ModelTagDetail{ParameterSize: "7.0B"}},
+		},
+	})
+	t.Setenv("OLLAMA_HOST", srv.URL)
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	err := runInvokeOllama(
+		context.Background(),
+		&invokeOllamaOpts{listMode: true},
+		nil, // no prompt args needed for --list
+		strings.NewReader(""),
+		stdout, stderr,
+	)
+	if err != nil {
+		t.Fatalf("runInvokeOllama --list: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "llama3.1:latest") {
+		t.Errorf("--list output missing llama3.1:latest; got %q", out)
+	}
+	if !strings.Contains(out, "deepseek-r1:7b") {
+		t.Errorf("--list output missing deepseek-r1:7b; got %q", out)
+	}
+	if !strings.Contains(out, "8.0B") {
+		t.Errorf("--list output missing parameter size 8.0B; got %q", out)
+	}
+}
+
+func TestInvokeOllamaListModeUnreachable(t *testing.T) {
+	t.Setenv("OLLAMA_HOST", "http://127.0.0.1:1")
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	err := runInvokeOllama(
+		context.Background(),
+		&invokeOllamaOpts{listMode: true},
+		nil,
+		strings.NewReader(""),
+		stdout, stderr,
+	)
+	if err == nil {
+		t.Fatal("expected error when daemon unreachable in --list mode")
+	}
+	if !strings.Contains(stderr.String(), "ollama serve") {
+		t.Errorf("stderr should hint 'ollama serve'; got %q", stderr.String())
+	}
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -16,7 +16,7 @@ func newRootCmd() *cobra.Command {
 
 Subcommands:
   invoke-claude    Send prompts to the Anthropic Messages API (PORTED)
-  invoke-ollama    Send prompts to a local Ollama instance     (stub)
+  invoke-ollama    Send prompts to a local Ollama instance    (PORTED)
   csbx             Plugin manager for CyberSandbox             (stub)
   harbinger        Phase-driven security testing CLI           (stub)
 

--- a/cli/cmd/stubs.go
+++ b/cli/cmd/stubs.go
@@ -10,10 +10,12 @@ import (
 // notYetPorted writes a helpful redirect to stderr and exits 2 so callers
 // can distinguish "feature unimplemented" (2) from "operation failed" (1).
 //
-// Phase 1 of spec 018 ships only invoke-claude as a real port. The other
-// three subcommands register so `cyberbox --help` lists the full surface,
-// but invoking them prints a pointer to the legacy bash file. This keeps
-// users out of "command not found" rabbit holes during the migration.
+// Phase 1 of spec 018 shipped invoke-claude as a real port. Phase 2
+// adds invoke-ollama (see invoke_ollama.go). The remaining two
+// subcommands (csbx, harbinger) register so `cyberbox --help` lists the
+// full surface, but invoking them prints a pointer to the legacy bash
+// file. This keeps users out of "command not found" rabbit holes during
+// the migration.
 func notYetPorted(name, bashPath string) func(cmd *cobra.Command, args []string) {
 	return func(cmd *cobra.Command, args []string) {
 		fmt.Fprintf(os.Stderr,
@@ -54,11 +56,7 @@ func newHarbingerCmd() *cobra.Command {
 	}
 }
 
-func newInvokeOllamaCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:                "invoke-ollama [args]...",
-		Short:              "(stub) Send prompts to a local Ollama instance",
-		DisableFlagParsing: true,
-		Run:                notYetPorted("invoke-ollama", "harbinger/bin/invoke-ollama"),
-	}
-}
+// newInvokeOllamaCmd was a stub in Phase 1; its real implementation
+// lives in invoke_ollama.go starting Phase 2. Kept here as a comment so
+// `git blame` makes the transition discoverable. The cobra registration
+// in root.go calls the real constructor now.

--- a/cli/internal/ollama/client.go
+++ b/cli/internal/ollama/client.go
@@ -1,0 +1,216 @@
+// Package ollama is a minimal client for a local Ollama daemon's HTTP API.
+//
+// We implement only what invoke-ollama needs: a non-streaming POST to
+// /api/generate (with optional system prompt and JSON-format flag) and a
+// GET to /api/tags for `--list`. No streaming, no chat-history threading,
+// no embeddings — those belong in a higher-level helper if/when needed.
+//
+// The client takes an *http.Client so tests can drive an httptest.Server
+// without touching a live daemon. Default timeouts mirror the bash
+// invoke-ollama defaults (300s overall, 5s connect) so behaviour matches
+// when no overrides are supplied.
+package ollama
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Defaults mirror the bash invoke-ollama script and Ollama's published
+// API conventions. OLLAMA_HOST is the legacy env var name; we keep it
+// rather than introducing a new one so existing scripts continue to work
+// after the bash file becomes a shim around this package.
+const (
+	DefaultEndpoint = "http://localhost:11434"
+	DefaultModel    = "llama3.1"
+
+	GeneratePath = "/api/generate"
+	TagsPath     = "/api/tags"
+
+	// Generate is long-running by design — local models on CPU can take
+	// minutes. 300s mirrors the bash OLLAMA_TIMEOUT default; tests
+	// override via the HTTPClient.
+	DefaultTimeout = 300 * time.Second
+)
+
+// Config carries everything needed to make a request. Zero values fall
+// back to the constants above.
+type Config struct {
+	Endpoint   string
+	HTTPClient *http.Client
+}
+
+// Client is the typed entry point. Construct via New so the defaults are
+// applied consistently.
+type Client struct {
+	cfg Config
+}
+
+func New(cfg Config) *Client {
+	if cfg.Endpoint == "" {
+		cfg.Endpoint = DefaultEndpoint
+	}
+	if cfg.HTTPClient == nil {
+		cfg.HTTPClient = &http.Client{Timeout: DefaultTimeout}
+	}
+	// Trim a trailing slash so we can reliably concatenate paths below.
+	cfg.Endpoint = strings.TrimRight(cfg.Endpoint, "/")
+	return &Client{cfg: cfg}
+}
+
+// Request mirrors the relevant subset of Ollama's /api/generate payload.
+// `Stream` is forced to false in Send — the streaming protocol is a
+// different beast we don't need yet.
+type Request struct {
+	Model  string `json:"model"`
+	Prompt string `json:"prompt"`
+	System string `json:"system,omitempty"`
+	// Format is "json" when JSON mode is requested; empty otherwise.
+	// Ollama treats any other value as "no format constraint".
+	Format string `json:"format,omitempty"`
+	Stream bool   `json:"stream"`
+}
+
+// Response is the trimmed payload we read back. Ollama returns more
+// fields (created_at, done_reason, prompt_eval_count, etc.) that we
+// ignore — encoding/json drops unknown fields silently.
+type Response struct {
+	Response      string `json:"response"`
+	Model         string `json:"model"`
+	TotalDuration int64  `json:"total_duration"` // nanoseconds
+	EvalCount     int    `json:"eval_count"`     // output tokens
+	Done          bool   `json:"done"`
+	Error         string `json:"error,omitempty"`
+}
+
+// TagsResponse is the shape returned by GET /api/tags. We only surface
+// the fields invoke-ollama --list cares about (name + size + parameter
+// size). Anything else Ollama emits gets ignored on decode.
+type TagsResponse struct {
+	Models []ModelTag `json:"models"`
+}
+
+type ModelTag struct {
+	Name    string         `json:"name"`
+	Size    int64          `json:"size"`
+	Details ModelTagDetail `json:"details"`
+}
+
+type ModelTagDetail struct {
+	ParameterSize string `json:"parameter_size"`
+}
+
+// Generate issues a non-streaming completion request. A populated
+// `error` field in the body is surfaced as a Go error so callers don't
+// have to inspect both the HTTP status and the JSON.
+func (c *Client) Generate(ctx context.Context, req Request) (*Response, error) {
+	if req.Model == "" {
+		req.Model = DefaultModel
+	}
+	req.Stream = false
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("encode request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.cfg.Endpoint+GeneratePath, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("build http request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	httpResp, err := c.cfg.HTTPClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("ollama request: %w", err)
+	}
+	defer httpResp.Body.Close()
+
+	respBytes, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	var resp Response
+	if err := json.Unmarshal(respBytes, &resp); err != nil {
+		return nil, fmt.Errorf("decode response (status %d, body=%q): %w",
+			httpResp.StatusCode, string(respBytes), err)
+	}
+
+	if resp.Error != "" {
+		return &resp, fmt.Errorf("ollama api error: %s", resp.Error)
+	}
+	if httpResp.StatusCode >= 400 {
+		return &resp, fmt.Errorf("ollama http %d: %s", httpResp.StatusCode, strings.TrimSpace(string(respBytes)))
+	}
+	return &resp, nil
+}
+
+// ListModels queries /api/tags. Used by `invoke-ollama --list`. A
+// daemon that isn't running surfaces as a connection error from the
+// underlying HTTP client.
+func (c *Client) ListModels(ctx context.Context) (*TagsResponse, error) {
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, c.cfg.Endpoint+TagsPath, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build http request: %w", err)
+	}
+
+	httpResp, err := c.cfg.HTTPClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("ollama tags request: %w", err)
+	}
+	defer httpResp.Body.Close()
+
+	respBytes, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read tags response: %w", err)
+	}
+
+	if httpResp.StatusCode >= 400 {
+		return nil, fmt.Errorf("ollama http %d: %s", httpResp.StatusCode, strings.TrimSpace(string(respBytes)))
+	}
+
+	var tags TagsResponse
+	if err := json.Unmarshal(respBytes, &tags); err != nil {
+		return nil, fmt.Errorf("decode tags response (body=%q): %w", string(respBytes), err)
+	}
+	return &tags, nil
+}
+
+// Ping returns nil if the daemon is reachable. Used by the CLI to give a
+// clearer error than a generic curl-style failure ("Ollama not running
+// at $OLLAMA_HOST — start it: ollama serve").
+func (c *Client) Ping(ctx context.Context) error {
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, c.cfg.Endpoint+TagsPath, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.cfg.HTTPClient.Do(httpReq)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	// Any 2xx-4xx response means the daemon answered the socket. 5xx is
+	// also "alive but unhappy" — still a successful ping for reachability.
+	if resp.StatusCode >= 200 && resp.StatusCode < 600 {
+		return nil
+	}
+	return errors.New("ollama returned no usable status")
+}
+
+// DurationSeconds converts the nanosecond total_duration from Generate
+// into a float seconds value the CLI prints in the dim usage footer.
+// Returns 0 if the response is nil or the duration is non-positive.
+func (r *Response) DurationSeconds() float64 {
+	if r == nil || r.TotalDuration <= 0 {
+		return 0
+	}
+	return float64(r.TotalDuration) / float64(time.Second)
+}

--- a/cli/internal/ollama/client_test.go
+++ b/cli/internal/ollama/client_test.go
@@ -1,0 +1,205 @@
+package ollama
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newFakeAPI returns a httptest server whose handler dispatches by path:
+// /api/generate echoes a configurable Response, /api/tags echoes a
+// configurable TagsResponse. The capture pointers (if non-nil) record
+// the most recent inbound Generate request body so tests can assert
+// what the client sent.
+func newFakeAPI(t *testing.T, capturedGen *Request, genReply Response, tagsReply TagsResponse) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc(GeneratePath, func(w http.ResponseWriter, r *http.Request) {
+		if capturedGen != nil {
+			_ = json.NewDecoder(r.Body).Decode(capturedGen)
+		}
+		_ = json.NewEncoder(w).Encode(genReply)
+	})
+	mux.HandleFunc(TagsPath, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(tagsReply)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestGenerateHappyPath(t *testing.T) {
+	var captured Request
+	srv := newFakeAPI(t, &captured, Response{
+		Response:      "this is the model output",
+		Model:         "llama3.1",
+		TotalDuration: int64(2 * time.Second),
+		EvalCount:     42,
+		Done:          true,
+	}, TagsResponse{})
+
+	c := New(Config{Endpoint: srv.URL})
+	resp, err := c.Generate(context.Background(), Request{
+		Model:  "llama3.1",
+		Prompt: "hello",
+	})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if resp.Response != "this is the model output" {
+		t.Errorf("Response = %q; want body text", resp.Response)
+	}
+	if resp.EvalCount != 42 {
+		t.Errorf("EvalCount = %d; want 42", resp.EvalCount)
+	}
+	if got := resp.DurationSeconds(); got != 2.0 {
+		t.Errorf("DurationSeconds = %v; want 2.0", got)
+	}
+	// Stream MUST be false on the wire — we don't support streaming.
+	if captured.Stream {
+		t.Error("Generate sent stream=true; client must always force false")
+	}
+	if captured.Model != "llama3.1" {
+		t.Errorf("captured.Model = %q; want llama3.1", captured.Model)
+	}
+}
+
+func TestGenerateAppliesDefaultModel(t *testing.T) {
+	var captured Request
+	srv := newFakeAPI(t, &captured, Response{Response: "ok", Done: true}, TagsResponse{})
+
+	c := New(Config{Endpoint: srv.URL})
+	if _, err := c.Generate(context.Background(), Request{Prompt: "hi"}); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if captured.Model != DefaultModel {
+		t.Errorf("captured.Model = %q; want default %q", captured.Model, DefaultModel)
+	}
+}
+
+func TestGenerateForwardsSystemAndJSONFormat(t *testing.T) {
+	var captured Request
+	srv := newFakeAPI(t, &captured, Response{Response: `{"k":1}`, Done: true}, TagsResponse{})
+
+	c := New(Config{Endpoint: srv.URL})
+	if _, err := c.Generate(context.Background(), Request{
+		Model:  "llama3.1",
+		Prompt: "extract endpoints",
+		System: "You are a security analyst.",
+		Format: "json",
+	}); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if captured.System != "You are a security analyst." {
+		t.Errorf("System mismatch: %q", captured.System)
+	}
+	if captured.Format != "json" {
+		t.Errorf("Format mismatch: %q", captured.Format)
+	}
+}
+
+func TestGenerateSurfacesAPIError(t *testing.T) {
+	srv := newFakeAPI(t, nil, Response{Error: "model 'made-up' not found"}, TagsResponse{})
+
+	c := New(Config{Endpoint: srv.URL})
+	_, err := c.Generate(context.Background(), Request{Model: "made-up", Prompt: "hi"})
+	if err == nil {
+		t.Fatal("expected error from API error field")
+	}
+	if !strings.Contains(err.Error(), "model 'made-up' not found") {
+		t.Errorf("error should include API message; got %v", err)
+	}
+}
+
+func TestGenerateSurfacesHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	c := New(Config{Endpoint: srv.URL})
+	_, err := c.Generate(context.Background(), Request{Model: "x", Prompt: "y"})
+	if err == nil {
+		t.Fatal("expected error on HTTP 500")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("error should include HTTP code; got %v", err)
+	}
+}
+
+func TestListModelsParses(t *testing.T) {
+	srv := newFakeAPI(t, nil, Response{}, TagsResponse{
+		Models: []ModelTag{
+			{Name: "llama3.1:latest", Size: 4_700_000_000, Details: ModelTagDetail{ParameterSize: "8.0B"}},
+			{Name: "deepseek-r1:7b", Size: 4_300_000_000, Details: ModelTagDetail{ParameterSize: "7.0B"}},
+		},
+	})
+
+	c := New(Config{Endpoint: srv.URL})
+	tags, err := c.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("ListModels: %v", err)
+	}
+	if len(tags.Models) != 2 {
+		t.Fatalf("got %d models; want 2", len(tags.Models))
+	}
+	if tags.Models[0].Name != "llama3.1:latest" {
+		t.Errorf("first model name = %q; want llama3.1:latest", tags.Models[0].Name)
+	}
+	if tags.Models[1].Details.ParameterSize != "7.0B" {
+		t.Errorf("second model parameter_size = %q; want 7.0B", tags.Models[1].Details.ParameterSize)
+	}
+}
+
+func TestPingReachesDaemon(t *testing.T) {
+	srv := newFakeAPI(t, nil, Response{}, TagsResponse{})
+
+	c := New(Config{Endpoint: srv.URL})
+	if err := c.Ping(context.Background()); err != nil {
+		t.Errorf("Ping should succeed against live server; got %v", err)
+	}
+}
+
+func TestPingFailsAgainstUnreachable(t *testing.T) {
+	// Use an unroutable address with a tight timeout so the test stays fast.
+	c := New(Config{
+		Endpoint:   "http://127.0.0.1:1",
+		HTTPClient: &http.Client{Timeout: 200 * time.Millisecond},
+	})
+	if err := c.Ping(context.Background()); err == nil {
+		t.Error("Ping should fail against unreachable endpoint")
+	}
+}
+
+func TestNewTrimsTrailingSlash(t *testing.T) {
+	c := New(Config{Endpoint: "http://localhost:11434/"})
+	if c.cfg.Endpoint != "http://localhost:11434" {
+		t.Errorf("trailing slash not trimmed: %q", c.cfg.Endpoint)
+	}
+}
+
+func TestNewAppliesDefaults(t *testing.T) {
+	c := New(Config{})
+	if c.cfg.Endpoint != DefaultEndpoint {
+		t.Errorf("default endpoint not applied: %q", c.cfg.Endpoint)
+	}
+	if c.cfg.HTTPClient == nil {
+		t.Error("default HTTPClient not applied")
+	}
+}
+
+func TestDurationSecondsZeroForNil(t *testing.T) {
+	var r *Response
+	if got := r.DurationSeconds(); got != 0 {
+		t.Errorf("nil DurationSeconds = %v; want 0", got)
+	}
+	r = &Response{TotalDuration: 0}
+	if got := r.DurationSeconds(); got != 0 {
+		t.Errorf("zero DurationSeconds = %v; want 0", got)
+	}
+}


### PR DESCRIPTION
Port harbinger/bin/invoke-ollama (148 bash lines) to Go with full behavioral parity. Same flag surface, same OLLAMA_HOST/OLLAMA_MODEL env-var precedence, same TTY-aware stderr footer, same --list output shape.

## What's in

- cli/internal/ollama/client.go: minimal client for /api/generate + /api/tags. Takes an *http.Client so tests drive an httptest.Server (no live daemon needed). Default endpoint http://localhost:11434, default model llama3.1, default timeout 300s — all mirroring the bash defaults.

- cli/internal/ollama/client_test.go: 11 tests covering happy path (Generate + ListModels), default-model fallback, system + JSON format forwarding, API error surfacing, HTTP error surfacing, Ping reachability, trailing-slash trimming, default application, nil-safe DurationSeconds.

- cli/cmd/invoke_ollama.go: cobra command + runInvokeOllama core. Same buildPrompt / isTerminal / colorCodes / firstNonEmpty helpers as invoke-claude (already in invoke_claude.go — shared at the package level so both commands stay aligned). --list path uses text/tabwriter to match the bash version's column alignment.

- cli/cmd/invoke_ollama_test.go: 11 tests covering happy path, model resolution chain (-m flag > $OLLAMA_MODEL > default), stdin concatenation, JSON mode, system prompt forwarding, no-prompt rejection, unreachable-daemon error (with 'ollama serve' hint), API error propagation, --list mode (full + unreachable cases).

- cli/cmd/stubs.go: invoke-ollama stub removed; csbx and harbinger stubs remain. Kept a comment explaining the transition for git blame.

- cli/cmd/root.go: subcommand-status table updated; invoke-ollama shows (PORTED) instead of (stub).

- cli/README.md: status table flipped to ✅ Ported (Phase 2). New Use-it section covers both invoke-claude and invoke-ollama with copy-pasteable invocations. Layout diagram updated.

## Verification

  cd cli
  go vet ./...                       → clean
  go test -race -count=1 ./...       → all pass
                                       cli/cmd                     ok
                                       cli/internal/anthropic      ok
                                       cli/internal/ollama         ok
  go build -o /tmp/cyberbox .        → produces working binary

  /tmp/cyberbox --help               → invoke-ollama listed (PORTED)
  /tmp/cyberbox invoke-ollama --help → full flag surface
  OLLAMA_HOST=http://127.0.0.1:1 \\
    /tmp/cyberbox invoke-ollama "hi" → clear error + 'ollama serve' hint

## Out of scope (deferred to follow-up)

- Bash compat test (harbinger/tests/test_invoke_ollama.sh) — adds when the bash file becomes a shim (Phase 5 of spec 018)
- Streaming /api/generate responses — current implementation forces stream=false; no caller needs streaming yet
- /api/chat (multi-turn) — bash invoke-ollama uses /api/generate exclusively; matching that
- /api/embeddings — out of invoke-ollama's scope

## What changed

<!-- Brief description -->

## Type

- [ ] Bug fix
- [ ] New feature
- [ ] New plugin (csbx registry)
- [ ] Docker/infra change
- [ ] Documentation

## Testing

<!-- How did you verify this works? -->

## Checklist

- [ ] Tested with `docker compose build`
- [ ] No secrets or .env files committed
- [ ] Updated SETUP.md if user-facing behavior changed
