### PR TITLE
feat(cli): csbx read-only subcommands port (spec 018, Phase 3-2a)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -10,8 +10,8 @@ files becoming thin shims once a Go implementation exists.
 | Subcommand | Status | Notes |
 |------------|--------|-------|
 | `cyberbox invoke-claude` | ✅ Ported (Phase 1) | Behavioral parity with `harbinger/bin/invoke-claude` |
-| `cyberbox invoke-ollama` | 🟡 Stub | Prints redirect to bash file |
-| `cyberbox csbx` | 🟡 Stub | Prints redirect to bash file |
+| `cyberbox invoke-ollama` | 🟡 Stub | Prints redirect to bash file (port pending merge of feat/spec-018-phase-2-ollama) |
+| `cyberbox csbx` | 🟢 PARTIAL (Phase 3-2a) | `search`, `info`, `list`, `doctor` ported; `verify` pending phase 3-2c; `install`/`remove`/`update`/`sync`/`pdtm` pending phase 3-3 |
 | `cyberbox harbinger` | 🟡 Stub | Prints redirect to bash file |
 
 Stubs exit with code **2** so callers can distinguish "not yet ported"
@@ -90,13 +90,22 @@ cli/
 ├── main.go                          # tiny entrypoint
 ├── cmd/
 │   ├── root.go                      # cobra root + version
-│   ├── invoke_claude.go             # the only fully ported command
+│   ├── invoke_claude.go             # Phase 1: Anthropic Messages API
 │   ├── invoke_claude_test.go        # table-driven tests via httptest
-│   └── stubs.go                     # csbx/harbinger/invoke-ollama redirect stubs
+│   ├── csbx/                        # Phase 3-2a: csbx subtree (read-only)
+│   │   ├── csbx.go                  # cobra subtree root
+│   │   ├── search.go / _test.go     # registry search by name/desc/tag
+│   │   ├── info.go / _test.go       # registry detail + install status
+│   │   ├── list.go / _test.go       # installed (default) or --available
+│   │   └── doctor.go / _test.go     # health check
+│   └── stubs.go                     # remaining stub redirects (invoke-ollama, harbinger)
 ├── internal/
-│   └── anthropic/
-│       ├── client.go                # minimal Messages API client
-│       └── client_test.go
+│   ├── anthropic/
+│   │   ├── client.go                # minimal Messages API client
+│   │   └── client_test.go
+│   └── csbx/                        # Phase 3-2a: typed state layer
+│       ├── state.go                 # Registry, Installed, Manifest types + Paths + I/O
+│       └── state_test.go
 ├── Makefile
 ├── .goreleaser.yaml                 # cosign-signed, SBOM-attached release config
 ├── go.mod / go.sum

--- a/cli/cmd/csbx/csbx.go
+++ b/cli/cmd/csbx/csbx.go
@@ -1,0 +1,39 @@
+// Package csbx is the cobra subcommand subtree for cybersandbox plugin
+// management. Spec 018 phase 3-2a lands the read-only subcommands
+// (search, info, list, doctor); subsequent phases add verify (3-2c)
+// and the mutating subcommands (3-3).
+//
+// Each subcommand lives in its own file (search.go, info.go, list.go,
+// doctor.go) so the surface stays browseable. NewCmd is the only
+// exported symbol — it wires the subtree onto the parent cobra root.
+package csbx
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// NewCmd returns the `cyberbox csbx ...` root with all read-only
+// subcommands registered. Mutating subcommands (install, remove,
+// update, sync, pdtm) will register here as they're ported in
+// phase 3-3.
+func NewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "csbx",
+		Short: "Plugin manager for CyberSandbox",
+		Long: `csbx — CyberSandbox plugin manager.
+
+Phases 3-2a and (forthcoming) 3-2c port the read-only subcommands.
+Mutating subcommands (install/remove/update/sync/pdtm) still resolve
+to the legacy bash 'csbx' file via the subcommand-not-found redirect
+until phase 3-3 lands them in Go too.`,
+		// SilenceUsage on subcommand errors — error message is enough,
+		// don't dump the whole usage block on every failure.
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	cmd.AddCommand(newSearchCmd())
+	cmd.AddCommand(newInfoCmd())
+	cmd.AddCommand(newListCmd())
+	cmd.AddCommand(newDoctorCmd())
+	return cmd
+}

--- a/cli/cmd/csbx/doctor.go
+++ b/cli/cmd/csbx/doctor.go
@@ -1,0 +1,144 @@
+package csbx
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	csbxstate "github.com/ProwlrBot/CyberBox/cli/internal/csbx"
+)
+
+func newDoctorCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "doctor",
+		Short: "Health check ($CSBX_HOME layout, broken symlinks, prereqs, plugin count)",
+		Long: `Reports on the health of $CSBX_HOME — directory layout,
+broken symlinks under bin/, presence of git in PATH (needed for install /
+update), the count of installed plugins, and total plugin storage.
+
+Read-only. Useful as a smoke test after a fresh install or before
+filing an issue.`,
+		Example: `  cyberbox csbx doctor`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDoctor(os.Stdout, os.Stderr)
+		},
+	}
+}
+
+// runDoctor walks $CSBX_HOME, prints structured status lines (one per
+// check) so a downstream parser can scrape pass/fail. The bash test
+// suite asserts existence of the [+]/[✓]/[!] markers — reproduce them
+// verbatim so the bash regression test passes when the bash file
+// becomes a shim.
+func runDoctor(stdout, stderr io.Writer) error {
+	paths, err := csbxstate.NewPaths()
+	if err != nil {
+		return err
+	}
+	if err := paths.EnsureDirs(); err != nil {
+		return err
+	}
+
+	fmt.Fprintln(stdout, "CyberSandbox Health Check")
+	fmt.Fprintln(stdout)
+
+	// 1) Directory tree
+	for _, dir := range []string{paths.Home, paths.Bin, paths.Plugins} {
+		if statIsDir(dir) {
+			fmt.Fprintf(stdout, "[✓] %s\n", dir)
+		} else {
+			fmt.Fprintf(stdout, "[!] %s missing\n", dir)
+		}
+	}
+
+	// 2) Broken symlinks under bin/. Walk only top-level entries — same
+	// semantics as bash `for link in "$CSBX_BIN"/*`.
+	broken := 0
+	binEntries, err := os.ReadDir(paths.Bin)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		fmt.Fprintf(stdout, "[!] cannot read %s: %v\n", paths.Bin, err)
+	} else {
+		for _, e := range binEntries {
+			full := filepath.Join(paths.Bin, e.Name())
+			info, err := os.Lstat(full)
+			if err != nil || info.Mode()&os.ModeSymlink == 0 {
+				continue
+			}
+			if _, err := os.Stat(full); err != nil {
+				fmt.Fprintf(stdout, "[!] Broken symlink: %s\n", full)
+				broken++
+			}
+		}
+	}
+	if broken == 0 {
+		fmt.Fprintln(stdout, "[✓] No broken symlinks")
+	}
+
+	// 3) git availability (needed for install/update). pyyaml from the
+	// bash version is no longer relevant — Go binary self-contains
+	// gopkg.in/yaml.v3.
+	if _, err := exec.LookPath("git"); err == nil {
+		fmt.Fprintln(stdout, "[✓] git available")
+	} else {
+		fmt.Fprintln(stdout, "[x] git missing")
+	}
+
+	// 4) Stats
+	fmt.Fprintln(stdout)
+	inst, err := paths.LoadInstalled()
+	if err != nil {
+		fmt.Fprintf(stdout, "[+] cannot read installed.yaml: %v\n", err)
+	} else {
+		fmt.Fprintf(stdout, "[+] %d plugin(s) installed\n", len(inst.Plugins))
+	}
+
+	size := dirSize(paths.Plugins)
+	fmt.Fprintf(stdout, "[+] Plugin storage: %s\n", humanSize(size))
+	return nil
+}
+
+func statIsDir(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+func dirSize(root string) int64 {
+	var total int64
+	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil // skip permission errors quietly
+		}
+		if d.IsDir() {
+			return nil
+		}
+		info, err := d.Info()
+		if err == nil {
+			total += info.Size()
+		}
+		return nil
+	})
+	return total
+}
+
+// humanSize formats `bytes` the way `du -sh` would — one decimal at the
+// largest sensible unit. Matches the bash `du -sh ... | cut -f1` shape
+// closely enough that the test_csbx.sh `[8] doctor` regex is happy.
+func humanSize(bytes int64) string {
+	const k = 1024
+	switch {
+	case bytes < k:
+		return fmt.Sprintf("%dB", bytes)
+	case bytes < k*k:
+		return fmt.Sprintf("%.1fK", float64(bytes)/k)
+	case bytes < k*k*k:
+		return fmt.Sprintf("%.1fM", float64(bytes)/(k*k))
+	default:
+		return fmt.Sprintf("%.1fG", float64(bytes)/(k*k*k))
+	}
+}

--- a/cli/cmd/csbx/doctor_test.go
+++ b/cli/cmd/csbx/doctor_test.go
@@ -1,0 +1,91 @@
+package csbx
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDoctorBootstrapsOnFreshHome(t *testing.T) {
+	home := withCSBXHome(t)
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if err := runDoctor(stdout, stderr); err != nil {
+		t.Fatalf("runDoctor: %v", err)
+	}
+	out := stdout.String()
+	for _, expect := range []string{
+		"CyberSandbox Health Check",
+		filepath.Join(home, "bin"),
+		filepath.Join(home, "plugins"),
+		"plugin(s) installed",
+		"Plugin storage:",
+	} {
+		if !strings.Contains(out, expect) {
+			t.Errorf("doctor output missing %q; got %q", expect, out)
+		}
+	}
+	// Bash test_csbx.sh [3] asserts installed.yaml is created on first run.
+	if _, err := os.Stat(filepath.Join(home, "installed.yaml")); err != nil {
+		t.Errorf("installed.yaml not created: %v", err)
+	}
+}
+
+func TestDoctorReportsBrokenSymlink(t *testing.T) {
+	home := withCSBXHome(t)
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if err := runDoctor(stdout, stderr); err != nil {
+		t.Fatalf("first runDoctor: %v", err)
+	}
+
+	// Now create a symlink in $CSBX_HOME/bin pointing at a non-existent target.
+	bin := filepath.Join(home, "bin")
+	dangling := filepath.Join(bin, "dangling")
+	if err := os.Symlink("/nonexistent/path/to/nowhere", dangling); err != nil {
+		t.Skipf("cannot create symlink (filesystem limitation): %v", err)
+	}
+
+	stdout.Reset()
+	if err := runDoctor(stdout, stderr); err != nil {
+		t.Fatalf("second runDoctor: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "Broken symlink") {
+		t.Errorf("expected 'Broken symlink' marker; got %q", out)
+	}
+	if strings.Contains(out, "[✓] No broken symlinks") {
+		t.Error("doctor reported clean state despite dangling symlink")
+	}
+}
+
+func TestDoctorCleanReportsNoBrokenSymlinks(t *testing.T) {
+	withCSBXHome(t)
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if err := runDoctor(stdout, stderr); err != nil {
+		t.Fatalf("runDoctor: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "No broken symlinks") {
+		t.Errorf("clean state should report 'No broken symlinks'; got %q", stdout.String())
+	}
+}
+
+func TestHumanSize(t *testing.T) {
+	cases := []struct {
+		bytes int64
+		want  string
+	}{
+		{0, "0B"},
+		{1023, "1023B"},
+		{1024, "1.0K"},
+		{1024 * 1024, "1.0M"},
+		{int64(1024) * 1024 * 1024, "1.0G"},
+		{int64(1.5 * 1024 * 1024), "1.5M"},
+	}
+	for _, c := range cases {
+		got := humanSize(c.bytes)
+		if got != c.want {
+			t.Errorf("humanSize(%d) = %q; want %q", c.bytes, got, c.want)
+		}
+	}
+}

--- a/cli/cmd/csbx/info.go
+++ b/cli/cmd/csbx/info.go
@@ -1,0 +1,92 @@
+package csbx
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	csbxstate "github.com/ProwlrBot/CyberBox/cli/internal/csbx"
+)
+
+func newInfoCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "info <plugin>",
+		Short: "Show plugin details from the registry plus install status",
+		Long: `Pretty-print one plugin's registry entry alongside its
+install status (path + installed-at timestamp from installed.yaml, or
+'Not installed').
+
+Read-only. Exits 0 even when the plugin is unknown — the printed
+message tells the user, the exit code distinguishes "operational error"
+from "informational answer".`,
+		Example: `  cyberbox csbx info seclists
+  cyberbox csbx info nuclei-templates`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runInfo(args[0], os.Stdout, os.Stderr)
+		},
+	}
+}
+
+func runInfo(name string, stdout, stderr io.Writer) error {
+	if err := csbxstate.ValidateName(name); err != nil {
+		fmt.Fprintf(stderr, "[x] %s\n", err)
+		return err
+	}
+	paths, err := csbxstate.NewPaths()
+	if err != nil {
+		return err
+	}
+	if err := paths.EnsureDirs(); err != nil {
+		return err
+	}
+
+	reg, err := paths.LoadRegistry()
+	if err != nil {
+		return err
+	}
+	entry, ok := reg.Plugins[name]
+	if !ok {
+		// Match bash csbx:225 — red "[x] Plugin "name" not in registry",
+		// return 0. This is a "user-information" path, not a fatal.
+		fmt.Fprintf(stdout, "[x] Plugin %q not in registry\n", name)
+		return nil
+	}
+
+	fmt.Fprintf(stdout, " %s\n", name)
+	fmt.Fprintf(stdout, "  Type:        %s\n", coalesce(entry.Type, "?"))
+	fmt.Fprintf(stdout, "  Description: %s\n", coalesce(entry.Description, "?"))
+	fmt.Fprintf(stdout, "  Repo:        %s\n", coalesce(entry.Repo, "?"))
+	fmt.Fprintf(stdout, "  Size:        %s\n", coalesce(entry.Size, "?"))
+	fmt.Fprintf(stdout, "  Tags:        %s\n", joinTags(entry.Tags))
+
+	inst, err := paths.LoadInstalled()
+	if err != nil {
+		return err
+	}
+	if iEntry, isInstalled := inst.Plugins[name]; isInstalled {
+		fmt.Fprintf(stdout, "  Installed:   %s at %s\n",
+			coalesce(iEntry.InstalledAt, "?"),
+			coalesce(iEntry.Path, "?"))
+	} else {
+		fmt.Fprintln(stdout, "  Not installed")
+	}
+	return nil
+}
+
+func coalesce(s, fallback string) string {
+	if s == "" {
+		return fallback
+	}
+	return s
+}
+
+func joinTags(tags []string) string {
+	if len(tags) == 0 {
+		return "(none)"
+	}
+	return strings.Join(tags, ", ")
+}

--- a/cli/cmd/csbx/info_test.go
+++ b/cli/cmd/csbx/info_test.go
@@ -1,0 +1,92 @@
+package csbx
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInfoNonExistentExitsZeroWithMessage(t *testing.T) {
+	home := withCSBXHome(t)
+	writeRegistry(t, home) // registry has seclists, fuzzdb, payloadsallthethings only
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	// Bash test_csbx.sh [6] asserts info on a nonexistent plugin
+	// reports 'not in registry' and does NOT crash. Go port matches.
+	if err := runInfo("nonexistent-plugin", stdout, stderr); err != nil {
+		t.Fatalf("runInfo nonexistent: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "not in registry") {
+		t.Errorf("expected 'not in registry'; got %q", stdout.String())
+	}
+}
+
+func TestInfoExistingPluginNotInstalled(t *testing.T) {
+	home := withCSBXHome(t)
+	writeRegistry(t, home)
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if err := runInfo("seclists", stdout, stderr); err != nil {
+		t.Fatalf("runInfo seclists: %v", err)
+	}
+	out := stdout.String()
+	for _, expect := range []string{
+		"seclists",
+		"Type:",
+		"wordlist",
+		"Repo:",
+		"github.com/danielmiessler/SecLists",
+		"Tags:",
+		"recon, fuzzing, passwords",
+		"Not installed",
+	} {
+		if !strings.Contains(out, expect) {
+			t.Errorf("info output missing %q; got %q", expect, out)
+		}
+	}
+	_ = stderr
+}
+
+func TestInfoExistingPluginInstalled(t *testing.T) {
+	home := withCSBXHome(t)
+	writeRegistry(t, home)
+	installed := `plugins:
+  seclists:
+    type: wordlist
+    repo: https://github.com/danielmiessler/SecLists
+    installed_at: "2026-04-25T01:23:45Z"
+    path: ` + filepath.Join(home, "plugins", "wordlists", "seclists") + `
+`
+	if err := os.WriteFile(filepath.Join(home, "installed.yaml"), []byte(installed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if err := runInfo("seclists", stdout, stderr); err != nil {
+		t.Fatalf("runInfo seclists: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "Installed:") {
+		t.Errorf("expected 'Installed:' line; got %q", out)
+	}
+	if !strings.Contains(out, "2026-04-25T01:23:45Z") {
+		t.Errorf("expected timestamp; got %q", out)
+	}
+	if strings.Contains(out, "Not installed") {
+		t.Errorf("should not print 'Not installed' for installed plugin; got %q", out)
+	}
+	_ = stderr
+}
+
+func TestInfoRejectsInvalidName(t *testing.T) {
+	withCSBXHome(t)
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if err := runInfo("../etc/passwd", stdout, stderr); err == nil {
+		t.Fatal("expected error for path-traversal name")
+	}
+	if !strings.Contains(stderr.String(), "invalid plugin name") {
+		t.Errorf("expected validation error; got %q", stderr.String())
+	}
+}

--- a/cli/cmd/csbx/list.go
+++ b/cli/cmd/csbx/list.go
@@ -1,0 +1,108 @@
+package csbx
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	csbxstate "github.com/ProwlrBot/CyberBox/cli/internal/csbx"
+)
+
+func newListCmd() *cobra.Command {
+	var available bool
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List installed plugins (or --available for the full registry)",
+		Long: `Print a table of installed plugins, one per row.
+
+With --available, prints the full registry catalog instead — equivalent
+to 'csbx search' with no query.`,
+		Example: `  cyberbox csbx list
+  cyberbox csbx list --available`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runList(available, os.Stdout, os.Stderr)
+		},
+	}
+	cmd.Flags().BoolVar(&available, "available", false, "List all registry plugins instead of installed")
+	return cmd
+}
+
+// runList is the testable core. EnsureDirs is called on every run so a
+// fresh $CSBX_HOME boots correctly without requiring `csbx doctor`
+// first — matches bash csbx, which calls ensure_dirs at the top of the
+// dispatcher (line 931).
+func runList(available bool, stdout, stderr io.Writer) error {
+	paths, err := csbxstate.NewPaths()
+	if err != nil {
+		return err
+	}
+	if err := paths.EnsureDirs(); err != nil {
+		return err
+	}
+
+	if available {
+		return listAvailable(paths, stdout, stderr)
+	}
+	return listInstalled(paths, stdout)
+}
+
+func listInstalled(paths *csbxstate.Paths, stdout io.Writer) error {
+	inst, err := paths.LoadInstalled()
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(stdout, "Installed plugins:")
+	if len(inst.Plugins) == 0 {
+		fmt.Fprintln(stdout, "  (none — try: cyberbox csbx install seclists)")
+		return nil
+	}
+	names := sortedKeys(inst.Plugins)
+	tw := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
+	for _, name := range names {
+		entry := inst.Plugins[name]
+		fmt.Fprintf(tw, "  %s\t%s\t%s\n", name, entry.Type, entry.Path)
+	}
+	return tw.Flush()
+}
+
+func listAvailable(paths *csbxstate.Paths, stdout, stderr io.Writer) error {
+	reg, err := paths.LoadRegistry()
+	if err != nil {
+		return err
+	}
+	if len(reg.Plugins) == 0 {
+		fmt.Fprintln(stderr, "Registry is empty or not synced — try: cyberbox csbx sync (when phase 3-3 lands)")
+		return nil
+	}
+	fmt.Fprintln(stdout, "Available plugins:")
+	names := sortedRegistryKeys(reg.Plugins)
+	tw := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
+	for _, name := range names {
+		entry := reg.Plugins[name]
+		fmt.Fprintf(tw, "  %s\t%s\t%s\t%s\n", name, entry.Type, entry.Size, entry.Description)
+	}
+	return tw.Flush()
+}
+
+func sortedKeys(m map[string]csbxstate.InstalledEntry) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func sortedRegistryKeys(m map[string]csbxstate.RegistryEntry) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/cli/cmd/csbx/list_test.go
+++ b/cli/cmd/csbx/list_test.go
@@ -1,0 +1,124 @@
+package csbx
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// withCSBXHome sets CSBX_HOME to a fresh tempdir for the test's
+// duration and returns it. Ensures the bash test_csbx.sh "use a temp
+// home so we don't touch the real one" pattern carries over to Go tests.
+func withCSBXHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("CSBX_HOME", home)
+	t.Setenv("CSBX_REGISTRY_URL", "")
+	return home
+}
+
+func TestListInstalledEmptyState(t *testing.T) {
+	withCSBXHome(t)
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if err := runList(false, stdout, stderr); err != nil {
+		t.Fatalf("runList: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "Installed plugins:") {
+		t.Errorf("missing header; got %q", out)
+	}
+	if !strings.Contains(out, "(none") {
+		t.Errorf("empty state should hint with '(none'; got %q", out)
+	}
+}
+
+func TestListInstalledSeededState(t *testing.T) {
+	home := withCSBXHome(t)
+	installed := `plugins:
+  seclists:
+    type: wordlist
+    repo: https://github.com/danielmiessler/SecLists
+    installed_at: "2026-04-25T01:00:00Z"
+    path: ` + filepath.Join(home, "plugins", "wordlists", "seclists") + `
+  subfinder:
+    type: tool
+    installed_at: "2026-04-25T01:01:00Z"
+    path: ` + filepath.Join(home, "bin", "subfinder") + `
+    source: pdtm
+`
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "installed.yaml"), []byte(installed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if err := runList(false, stdout, stderr); err != nil {
+		t.Fatalf("runList: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "seclists") {
+		t.Errorf("seclists missing; got %q", out)
+	}
+	if !strings.Contains(out, "subfinder") {
+		t.Errorf("subfinder missing; got %q", out)
+	}
+	// Sorted: seclists comes before subfinder alphabetically.
+	if strings.Index(out, "seclists") >= strings.Index(out, "subfinder") {
+		t.Errorf("expected sorted order seclists < subfinder; got %q", out)
+	}
+}
+
+func TestListAvailableNoRegistry(t *testing.T) {
+	withCSBXHome(t)
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if err := runList(true, stdout, stderr); err != nil {
+		t.Fatalf("runList --available with no registry: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "Registry") {
+		t.Errorf("missing registry-empty hint on stderr; got %q", stderr.String())
+	}
+}
+
+func TestListAvailableWithRegistry(t *testing.T) {
+	home := withCSBXHome(t)
+	registry := `version: 1
+plugins:
+  seclists:
+    repo: https://github.com/danielmiessler/SecLists
+    type: wordlist
+    description: "Discovery and password lists"
+    size: "1.2GB"
+    tags: [recon, fuzzing]
+  fuzzdb:
+    repo: https://github.com/fuzzdb-project/fuzzdb
+    type: wordlist
+    description: "Attack patterns and payload lists"
+    size: "60MB"
+    tags: [fuzzing, payloads]
+`
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "registry.yaml"), []byte(registry), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if err := runList(true, stdout, stderr); err != nil {
+		t.Fatalf("runList --available: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "Available plugins:") {
+		t.Errorf("missing header; got %q", out)
+	}
+	if !strings.Contains(out, "seclists") || !strings.Contains(out, "fuzzdb") {
+		t.Errorf("missing plugin rows; got %q", out)
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("stderr should be empty when registry has entries; got %q", stderr.String())
+	}
+}

--- a/cli/cmd/csbx/search.go
+++ b/cli/cmd/csbx/search.go
@@ -1,0 +1,100 @@
+package csbx
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	csbxstate "github.com/ProwlrBot/CyberBox/cli/internal/csbx"
+)
+
+func newSearchCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "search [query]",
+		Short: "Search the registry by name, description, or tag",
+		Long: `Search the cached upstream registry for plugins whose name,
+description, or tag matches QUERY (case-insensitive substring). Empty
+QUERY lists all plugins.
+
+Read-only. If no registry is cached yet, prints a hint to run sync (or
+returns an empty list quietly when phase 3-3 lands sync).`,
+		Example: `  cyberbox csbx search             # list all
+  cyberbox csbx search xss         # by tag/description
+  cyberbox csbx search seclists    # by name`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			query := ""
+			if len(args) == 1 {
+				query = args[0]
+			}
+			return runSearch(query, os.Stdout, os.Stderr)
+		},
+	}
+}
+
+func runSearch(query string, stdout, stderr io.Writer) error {
+	paths, err := csbxstate.NewPaths()
+	if err != nil {
+		return err
+	}
+	if err := paths.EnsureDirs(); err != nil {
+		return err
+	}
+	reg, err := paths.LoadRegistry()
+	if err != nil {
+		return err
+	}
+	if len(reg.Plugins) == 0 {
+		// Same fallback hint as bash csbx — without a cached registry,
+		// search has nothing to look at. Don't auto-sync; that's the
+		// user's choice (will be 'cyberbox csbx sync' once phase 3-3 lands).
+		fmt.Fprintln(stderr, "Registry not synced. Run 'cyberbox csbx sync' (or use the legacy bash 'csbx sync' until phase 3-3 lands).")
+		return nil
+	}
+
+	q := strings.ToLower(query)
+	names := make([]string, 0, len(reg.Plugins))
+	for name := range reg.Plugins {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	tw := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
+	matched := 0
+	for _, name := range names {
+		entry := reg.Plugins[name]
+		if !matches(name, entry, q) {
+			continue
+		}
+		fmt.Fprintf(tw, "  %s\t%s\t%s\t%s\n",
+			name, entry.Type, entry.Size, truncDesc(entry.Description, 60))
+		matched++
+	}
+	if err := tw.Flush(); err != nil {
+		return err
+	}
+	if matched == 0 && q != "" {
+		fmt.Fprintf(stderr, "No plugins matched %q.\n", query)
+	}
+	return nil
+}
+
+func matches(name string, entry csbxstate.RegistryEntry, lowerQuery string) bool {
+	if lowerQuery == "" {
+		return true
+	}
+	hay := strings.ToLower(name) + " " + strings.ToLower(entry.Description) + " " + strings.ToLower(strings.Join(entry.Tags, " "))
+	return strings.Contains(hay, lowerQuery)
+}
+
+func truncDesc(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}

--- a/cli/cmd/csbx/search_test.go
+++ b/cli/cmd/csbx/search_test.go
@@ -1,0 +1,128 @@
+package csbx
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeRegistry(t *testing.T, home string) {
+	t.Helper()
+	registry := `version: 1
+plugins:
+  seclists:
+    repo: https://github.com/danielmiessler/SecLists
+    type: wordlist
+    description: "Discovery, fuzzing, and password lists"
+    size: "1.2GB"
+    tags: [recon, fuzzing, passwords]
+  payloadsallthethings:
+    repo: https://github.com/swisskyrepo/PayloadsAllTheThings
+    type: wordlist
+    description: "Payload lists for web app security"
+    size: "200MB"
+    tags: [payloads, injection, xss, sqli]
+  fuzzdb:
+    repo: https://github.com/fuzzdb-project/fuzzdb
+    type: wordlist
+    description: "Attack patterns and payload lists"
+    size: "60MB"
+    tags: [fuzzing, payloads]
+`
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "registry.yaml"), []byte(registry), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSearchEmptyQueryListsAll(t *testing.T) {
+	home := withCSBXHome(t)
+	writeRegistry(t, home)
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if err := runSearch("", stdout, stderr); err != nil {
+		t.Fatalf("runSearch: %v", err)
+	}
+	out := stdout.String()
+	for _, name := range []string{"seclists", "fuzzdb", "payloadsallthethings"} {
+		if !strings.Contains(out, name) {
+			t.Errorf("missing %s; got %q", name, out)
+		}
+	}
+}
+
+func TestSearchByTagSubstring(t *testing.T) {
+	home := withCSBXHome(t)
+	writeRegistry(t, home)
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if err := runSearch("xss", stdout, stderr); err != nil {
+		t.Fatalf("runSearch xss: %v", err)
+	}
+	out := stdout.String()
+	// xss is a tag of payloadsallthethings only.
+	if !strings.Contains(out, "payloadsallthethings") {
+		t.Errorf("expected payloadsallthethings; got %q", out)
+	}
+	if strings.Contains(out, "seclists") {
+		t.Errorf("xss should not match seclists; got %q", out)
+	}
+}
+
+func TestSearchByDescriptionSubstring(t *testing.T) {
+	home := withCSBXHome(t)
+	writeRegistry(t, home)
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if err := runSearch("password", stdout, stderr); err != nil {
+		t.Fatalf("runSearch password: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "seclists") {
+		t.Errorf("seclists has 'password' in description; got %q", out)
+	}
+}
+
+func TestSearchCaseInsensitive(t *testing.T) {
+	home := withCSBXHome(t)
+	writeRegistry(t, home)
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if err := runSearch("FUZZING", stdout, stderr); err != nil {
+		t.Fatalf("runSearch FUZZING: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "seclists") {
+		t.Errorf("FUZZING should match seclists (tag fuzzing); got %q", stdout.String())
+	}
+}
+
+func TestSearchNoMatchPrintsHint(t *testing.T) {
+	home := withCSBXHome(t)
+	writeRegistry(t, home)
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if err := runSearch("nothing-matches-this", stdout, stderr); err != nil {
+		t.Fatalf("runSearch: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "No plugins matched") {
+		t.Errorf("expected no-match hint on stderr; got %q", stderr.String())
+	}
+}
+
+func TestSearchNoRegistryHints(t *testing.T) {
+	withCSBXHome(t)
+	// Don't write registry.yaml.
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if err := runSearch("anything", stdout, stderr); err != nil {
+		t.Fatalf("runSearch with no registry: %v", err)
+	}
+	// Bash test_csbx.sh [5] tolerates 'sync|registry|no|fuzzing' — match 'sync' or 'Registry'.
+	if !strings.Contains(stderr.String(), "Registry") &&
+		!strings.Contains(stderr.String(), "sync") {
+		t.Errorf("expected sync/Registry hint on stderr; got %q", stderr.String())
+	}
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+
+	csbxcmd "github.com/ProwlrBot/CyberBox/cli/cmd/csbx"
 )
 
 // Version is set at link time via -ldflags. Defaults to "dev" for unreleased
@@ -17,11 +19,14 @@ func newRootCmd() *cobra.Command {
 Subcommands:
   invoke-claude    Send prompts to the Anthropic Messages API (PORTED)
   invoke-ollama    Send prompts to a local Ollama instance     (stub)
-  csbx             Plugin manager for CyberSandbox             (stub)
+  csbx             Plugin manager for CyberSandbox             (PARTIAL — read-only ported)
   harbinger        Phase-driven security testing CLI           (stub)
 
-Stubs print a redirect to the equivalent bash script. The full port
-lands incrementally. See cli/README.md for the migration plan.`,
+Stubs print a redirect to the equivalent bash script. csbx PARTIAL
+means search/info/list/doctor are real Go implementations; install/
+remove/update/sync/pdtm/verify still resolve to bash via the
+not-yet-ported message. The full port lands incrementally — see
+cli/README.md for the migration plan.`,
 		Version:       Version,
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -29,7 +34,7 @@ lands incrementally. See cli/README.md for the migration plan.`,
 
 	root.AddCommand(newInvokeClaudeCmd())
 	root.AddCommand(newInvokeOllamaCmd())
-	root.AddCommand(newCsbxCmd())
+	root.AddCommand(csbxcmd.NewCmd()) // search/info/list/doctor are real; mutating subcommands fall through to the legacy bash csbx
 	root.AddCommand(newHarbingerCmd())
 	return root
 }

--- a/cli/cmd/stubs.go
+++ b/cli/cmd/stubs.go
@@ -10,10 +10,13 @@ import (
 // notYetPorted writes a helpful redirect to stderr and exits 2 so callers
 // can distinguish "feature unimplemented" (2) from "operation failed" (1).
 //
-// Phase 1 of spec 018 ships only invoke-claude as a real port. The other
-// three subcommands register so `cyberbox --help` lists the full surface,
-// but invoking them prints a pointer to the legacy bash file. This keeps
-// users out of "command not found" rabbit holes during the migration.
+// Phase 1 of spec 018 shipped invoke-claude as a real port. Phase 3-2a
+// ships csbx's read-only subcommands (search/info/list/doctor — see
+// cli/cmd/csbx/). The remaining subcommands (invoke-ollama as a fully
+// integrated stub, harbinger entirely) register so `cyberbox --help`
+// lists the full surface, but invoking them prints a pointer to the
+// legacy bash file. This keeps users out of "command not found" rabbit
+// holes during the migration.
 func notYetPorted(name, bashPath string) func(cmd *cobra.Command, args []string) {
 	return func(cmd *cobra.Command, args []string) {
 		fmt.Fprintf(os.Stderr,
@@ -36,14 +39,11 @@ func joinArgs(args []string) string {
 	return out
 }
 
-func newCsbxCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:                "csbx [args]...",
-		Short:              "(stub) Plugin manager for CyberSandbox",
-		DisableFlagParsing: true, // pass-through to the bash script
-		Run:                notYetPorted("csbx", "harbinger/bin/csbx"),
-	}
-}
+// newCsbxCmd was a full stub; phase 3-2a replaces it with a real cobra
+// subtree at cli/cmd/csbx/ that handles search/info/list/doctor and
+// returns a 'not yet ported' redirect for the mutating subcommands
+// (install/remove/update/sync/pdtm/verify). The wiring lives in
+// cli/cmd/root.go which now calls csbxcmd.NewCmd() directly.
 
 func newHarbingerCmd() *cobra.Command {
 	return &cobra.Command{

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -5,6 +5,7 @@ go 1.26.2
 require (
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/term v0.42.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -11,4 +11,7 @@ golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
 golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.42.0 h1:UiKe+zDFmJobeJ5ggPwOshJIVt6/Ft0rcfrXZDLWAWY=
 golang.org/x/term v0.42.0/go.mod h1:Dq/D+snpsbazcBG5+F9Q1n2rXV8Ma+71xEjTRufARgY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/cli/internal/csbx/state.go
+++ b/cli/internal/csbx/state.go
@@ -1,0 +1,243 @@
+// Package csbx is the typed state layer for cybersandbox plugin
+// management. The bash csbx persists two YAML files under $CSBX_HOME —
+// registry.yaml (cached upstream catalog) and installed.yaml (local
+// install record). This package gives both files typed Go structs so
+// the cmd/csbx subcommands operate on values, not interface{} blobs.
+//
+// Spec 018 phase 3-2a, layered on the audit at
+// cli/cmd/csbx/PORT_AUDIT.md.
+package csbx
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Registry mirrors the upstream csbx-registry.yaml format. Spec 011's
+// intake CI is the source of truth for what fields the registry can
+// carry; we add new fields as Spec 011 does.
+type Registry struct {
+	Version int                      `yaml:"version"`
+	Plugins map[string]RegistryEntry `yaml:"plugins"`
+}
+
+// RegistryEntry describes one plugin in the catalog. Spec 012 will add
+// SignatureURL/Identity/OIDCIssuer for cosign-gated installs; the
+// fields are pre-declared so the struct doesn't shift shape later.
+type RegistryEntry struct {
+	Repo        string   `yaml:"repo"`
+	Type        string   `yaml:"type"`
+	Description string   `yaml:"description,omitempty"`
+	Size        string   `yaml:"size,omitempty"`
+	Tags        []string `yaml:"tags,omitempty"`
+
+	// Reserved for spec 012. Empty until then.
+	SignatureURL string `yaml:"signature_url,omitempty"`
+	Identity     string `yaml:"identity,omitempty"`
+	OIDCIssuer   string `yaml:"oidc_issuer,omitempty"`
+}
+
+// Installed mirrors $CSBX_HOME/installed.yaml.
+type Installed struct {
+	Plugins map[string]InstalledEntry `yaml:"plugins"`
+}
+
+// InstalledEntry records what `csbx install` wrote. Source distinguishes
+// pdtm-installed (`go install`) from git-cloned (default empty); the
+// bash csbx records `source: pdtm` only for pdtm and leaves it omitted
+// otherwise.
+type InstalledEntry struct {
+	Type        string `yaml:"type"`
+	Repo        string `yaml:"repo,omitempty"`
+	InstalledAt string `yaml:"installed_at"`
+	Path        string `yaml:"path"`
+	Source      string `yaml:"source,omitempty"`
+}
+
+// Manifest is the per-plugin csbx.yaml shape. install/post_install/
+// uninstall are multi-line shell scripts; the Go port executes them via
+// `bash -c` (or `sh -c` fallback) preserving the bash semantics.
+type Manifest struct {
+	Type        string   `yaml:"type"`
+	Binaries    []string `yaml:"binaries,omitempty"`
+	Install     string   `yaml:"install,omitempty"`
+	PostInstall string   `yaml:"post_install,omitempty"`
+	Uninstall   string   `yaml:"uninstall,omitempty"`
+}
+
+// Paths bundles every filesystem location csbx cares about. Construct
+// via NewPaths so the env-var defaults match the bash csbx exactly.
+type Paths struct {
+	Home          string // $CSBX_HOME, default $HOME/.csbx
+	Bin           string // $CSBX_HOME/bin
+	Plugins       string // $CSBX_HOME/plugins
+	Registry      string // $CSBX_HOME/registry.yaml
+	Installed     string // $CSBX_HOME/installed.yaml
+	RegistryURL   string // $CSBX_REGISTRY_URL or upstream default
+}
+
+// DefaultRegistryURL is the upstream catalog. Override via $CSBX_REGISTRY_URL.
+const DefaultRegistryURL = "https://raw.githubusercontent.com/ProwlrBot/csbx-registry/main/registry.yaml"
+
+// PluginTypeDirs are the subdirs under $CSBX_HOME/plugins that
+// EnsureDirs creates. Mirrors the bash ensure_dirs at csbx:28-36.
+var PluginTypeDirs = []string{"tools", "wordlists", "nuclei-templates", "themes", "configs"}
+
+// NewPaths resolves $CSBX_HOME (defaulting to $HOME/.csbx) and derives
+// every other path. Honors $CSBX_REGISTRY_URL for the registry source.
+func NewPaths() (*Paths, error) {
+	home := os.Getenv("CSBX_HOME")
+	if home == "" {
+		userHome, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("resolve home directory: %w", err)
+		}
+		home = filepath.Join(userHome, ".csbx")
+	}
+	registryURL := os.Getenv("CSBX_REGISTRY_URL")
+	if registryURL == "" {
+		registryURL = DefaultRegistryURL
+	}
+	return &Paths{
+		Home:        home,
+		Bin:         filepath.Join(home, "bin"),
+		Plugins:     filepath.Join(home, "plugins"),
+		Registry:    filepath.Join(home, "registry.yaml"),
+		Installed:   filepath.Join(home, "installed.yaml"),
+		RegistryURL: registryURL,
+	}, nil
+}
+
+// EnsureDirs creates $CSBX_HOME/{bin,plugins/{tools,wordlists,...}} and
+// bootstraps installed.yaml with `plugins: {}` if missing. Idempotent.
+// Mirrors bash csbx:28-36 + 30 (installed.yaml init).
+func (p *Paths) EnsureDirs() error {
+	if err := os.MkdirAll(p.Bin, 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", p.Bin, err)
+	}
+	for _, sub := range PluginTypeDirs {
+		dir := filepath.Join(p.Plugins, sub)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("mkdir %s: %w", dir, err)
+		}
+	}
+	if _, err := os.Stat(p.Installed); errors.Is(err, os.ErrNotExist) {
+		if err := os.WriteFile(p.Installed, []byte("plugins: {}\n"), 0o644); err != nil {
+			return fmt.Errorf("init %s: %w", p.Installed, err)
+		}
+	}
+	return nil
+}
+
+// LoadRegistry reads p.Registry. Returns an empty Registry (no error) if
+// the file is missing — matches the bash lazy-sync semantics where
+// callers can decide whether to trigger a sync.
+func (p *Paths) LoadRegistry() (*Registry, error) {
+	return loadYAMLFile[Registry](p.Registry)
+}
+
+// LoadInstalled reads p.Installed. EnsureDirs guarantees the file
+// exists, so a missing file at this layer is a programmer error rather
+// than a soft-fail case.
+func (p *Paths) LoadInstalled() (*Installed, error) {
+	return loadYAMLFile[Installed](p.Installed)
+}
+
+// LoadManifest reads a plugin's csbx.yaml. Returns nil if the manifest
+// doesn't exist (some plugins ship without one — wordlist repos for
+// instance).
+func LoadManifest(path string) (*Manifest, error) {
+	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	return loadYAMLFile[Manifest](path)
+}
+
+// loadYAMLFile is the shared YAML reader. Generic over the target type
+// so each Load function gets typed output without copy-paste.
+func loadYAMLFile[T any](path string) (*T, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			var zero T
+			return &zero, nil
+		}
+		return nil, fmt.Errorf("open %s: %w", path, err)
+	}
+	defer f.Close()
+	bytes, err := io.ReadAll(f)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var v T
+	if err := yaml.Unmarshal(bytes, &v); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return &v, nil
+}
+
+// SaveInstalled writes p.Installed atomically. Writes to a temp file in
+// the same directory, then renames — so a partial write can never
+// corrupt the canonical file.
+func (p *Paths) SaveInstalled(inst *Installed) error {
+	bytes, err := yaml.Marshal(inst)
+	if err != nil {
+		return fmt.Errorf("encode installed.yaml: %w", err)
+	}
+	tmp, err := os.CreateTemp(p.Home, "installed-*.yaml")
+	if err != nil {
+		return fmt.Errorf("temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) // no-op if rename succeeded
+	if _, err := tmp.Write(bytes); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp: %w", err)
+	}
+	if err := os.Rename(tmpName, p.Installed); err != nil {
+		return fmt.Errorf("rename to %s: %w", p.Installed, err)
+	}
+	return nil
+}
+
+// validNameRE enforces the same constraint as bash csbx:89-96
+// validate_name. Alphanumeric plus dot/dash/underscore; the `..`
+// path-traversal test is implicit (the regex denies anything outside
+// the alphabet).
+var validNameRE = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+
+// ValidateName mirrors bash csbx:89-96 plus a hardening fix the audit
+// flagged: bash only rejects "../" but lets bare "." and ".." through.
+// We reject those explicitly because they're dangerous as path
+// components even without a trailing slash. Returns nil if `name` is
+// safe to use as a path component, an error otherwise.
+//
+// The audit also flagged that `csbx.yaml.type` should be validated by
+// the same function before being used to construct a target dir
+// (otherwise a malicious registry entry could path-traverse). Helpers
+// that build paths from manifest fields should call this.
+func ValidateName(name string) error {
+	if name == "" {
+		return errors.New("plugin name cannot be empty")
+	}
+	if name == "." || name == ".." {
+		return fmt.Errorf("invalid plugin name %q: reserved path component", name)
+	}
+	if strings.Contains(name, "../") {
+		return fmt.Errorf("invalid plugin name %q: contains path traversal", name)
+	}
+	if !validNameRE.MatchString(name) {
+		return fmt.Errorf("invalid plugin name %q: only alphanumeric, dot, dash, underscore allowed", name)
+	}
+	return nil
+}

--- a/cli/internal/csbx/state_test.go
+++ b/cli/internal/csbx/state_test.go
@@ -1,0 +1,289 @@
+package csbx
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func tempPaths(t *testing.T) *Paths {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("CSBX_HOME", home)
+	t.Setenv("CSBX_REGISTRY_URL", "")
+	p, err := NewPaths()
+	if err != nil {
+		t.Fatalf("NewPaths: %v", err)
+	}
+	if p.Home != home {
+		t.Fatalf("Home = %q; want %q", p.Home, home)
+	}
+	return p
+}
+
+func TestNewPathsHonorsEnv(t *testing.T) {
+	p := tempPaths(t)
+	if p.Bin != filepath.Join(p.Home, "bin") {
+		t.Errorf("Bin = %q; want under Home", p.Bin)
+	}
+	if p.RegistryURL != DefaultRegistryURL {
+		t.Errorf("RegistryURL = %q; want default", p.RegistryURL)
+	}
+}
+
+func TestNewPathsHonorsRegistryURLOverride(t *testing.T) {
+	t.Setenv("CSBX_HOME", t.TempDir())
+	t.Setenv("CSBX_REGISTRY_URL", "https://example.com/reg.yaml")
+	p, err := NewPaths()
+	if err != nil {
+		t.Fatalf("NewPaths: %v", err)
+	}
+	if p.RegistryURL != "https://example.com/reg.yaml" {
+		t.Errorf("RegistryURL = %q; want override", p.RegistryURL)
+	}
+}
+
+func TestEnsureDirsCreatesTreeAndBootstrapsInstalled(t *testing.T) {
+	p := tempPaths(t)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatalf("EnsureDirs: %v", err)
+	}
+	for _, sub := range PluginTypeDirs {
+		dir := filepath.Join(p.Plugins, sub)
+		if _, err := os.Stat(dir); err != nil {
+			t.Errorf("%s missing: %v", dir, err)
+		}
+	}
+	if _, err := os.Stat(p.Bin); err != nil {
+		t.Errorf("bin dir missing: %v", err)
+	}
+	bytes, err := os.ReadFile(p.Installed)
+	if err != nil {
+		t.Fatalf("read installed.yaml: %v", err)
+	}
+	if !strings.Contains(string(bytes), "plugins:") {
+		t.Errorf("installed.yaml content = %q; want plugins: bootstrap", string(bytes))
+	}
+}
+
+func TestEnsureDirsIdempotent(t *testing.T) {
+	p := tempPaths(t)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatalf("first EnsureDirs: %v", err)
+	}
+	// Mutate installed.yaml so we can assert we didn't clobber it on
+	// the second pass.
+	custom := []byte("plugins:\n  acme:\n    type: tool\n    path: /x\n    installed_at: '2026-01-01'\n")
+	if err := os.WriteFile(p.Installed, custom, 0o644); err != nil {
+		t.Fatalf("write custom installed.yaml: %v", err)
+	}
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatalf("second EnsureDirs: %v", err)
+	}
+	bytes, err := os.ReadFile(p.Installed)
+	if err != nil {
+		t.Fatalf("re-read installed.yaml: %v", err)
+	}
+	if !strings.Contains(string(bytes), "acme") {
+		t.Error("EnsureDirs clobbered existing installed.yaml")
+	}
+}
+
+func TestLoadRegistryMissingReturnsEmptyNoError(t *testing.T) {
+	p := tempPaths(t)
+	reg, err := p.LoadRegistry()
+	if err != nil {
+		t.Fatalf("LoadRegistry on missing file: %v", err)
+	}
+	if reg == nil {
+		t.Fatal("LoadRegistry returned nil; want zero value")
+	}
+	if len(reg.Plugins) != 0 {
+		t.Errorf("Plugins = %v; want empty", reg.Plugins)
+	}
+}
+
+func TestLoadRegistryParsesPlugins(t *testing.T) {
+	p := tempPaths(t)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatalf("EnsureDirs: %v", err)
+	}
+	yaml := `version: 1
+plugins:
+  seclists:
+    repo: https://github.com/danielmiessler/SecLists
+    type: wordlist
+    description: "Discovery and password lists"
+    size: "1.2GB"
+    tags: [recon, fuzzing]
+  nuclei-templates:
+    repo: https://github.com/projectdiscovery/nuclei-templates
+    type: nuclei-templates
+    size: "180MB"
+`
+	if err := os.WriteFile(p.Registry, []byte(yaml), 0o644); err != nil {
+		t.Fatalf("write registry.yaml: %v", err)
+	}
+	reg, err := p.LoadRegistry()
+	if err != nil {
+		t.Fatalf("LoadRegistry: %v", err)
+	}
+	if reg.Version != 1 {
+		t.Errorf("Version = %d; want 1", reg.Version)
+	}
+	if len(reg.Plugins) != 2 {
+		t.Fatalf("Plugins count = %d; want 2", len(reg.Plugins))
+	}
+	sec := reg.Plugins["seclists"]
+	if sec.Repo != "https://github.com/danielmiessler/SecLists" {
+		t.Errorf("seclists.Repo = %q", sec.Repo)
+	}
+	if got := sec.Tags; len(got) != 2 || got[0] != "recon" || got[1] != "fuzzing" {
+		t.Errorf("seclists.Tags = %v", got)
+	}
+}
+
+func TestLoadInstalledRoundtripsViaSave(t *testing.T) {
+	p := tempPaths(t)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatalf("EnsureDirs: %v", err)
+	}
+	inst := &Installed{
+		Plugins: map[string]InstalledEntry{
+			"seclists": {
+				Type:        "wordlist",
+				Repo:        "https://github.com/danielmiessler/SecLists",
+				InstalledAt: "2026-04-25T12:00:00Z",
+				Path:        filepath.Join(p.Plugins, "wordlists", "seclists"),
+			},
+			"subfinder": {
+				Type:        "tool",
+				InstalledAt: "2026-04-25T12:01:00Z",
+				Path:        filepath.Join(p.Bin, "subfinder"),
+				Source:      "pdtm",
+			},
+		},
+	}
+	if err := p.SaveInstalled(inst); err != nil {
+		t.Fatalf("SaveInstalled: %v", err)
+	}
+	round, err := p.LoadInstalled()
+	if err != nil {
+		t.Fatalf("LoadInstalled: %v", err)
+	}
+	if len(round.Plugins) != 2 {
+		t.Fatalf("Plugins count = %d; want 2", len(round.Plugins))
+	}
+	if round.Plugins["subfinder"].Source != "pdtm" {
+		t.Errorf("subfinder.Source = %q; want pdtm", round.Plugins["subfinder"].Source)
+	}
+	if round.Plugins["seclists"].Source != "" {
+		t.Errorf("seclists.Source = %q; want empty (omitempty)", round.Plugins["seclists"].Source)
+	}
+}
+
+func TestLoadManifestMissingReturnsNilNoError(t *testing.T) {
+	m, err := LoadManifest(filepath.Join(t.TempDir(), "csbx.yaml"))
+	if err != nil {
+		t.Fatalf("LoadManifest on missing file: %v", err)
+	}
+	if m != nil {
+		t.Errorf("got %+v; want nil for missing manifest", m)
+	}
+}
+
+func TestLoadManifestParsesHookScripts(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "csbx.yaml")
+	yaml := `type: tool
+binaries:
+  - bin/example
+install: |
+  echo "installing"
+  make
+post_install: |
+  echo "done"
+uninstall: |
+  rm -rf build/
+`
+	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m, err := LoadManifest(path)
+	if err != nil {
+		t.Fatalf("LoadManifest: %v", err)
+	}
+	if m.Type != "tool" {
+		t.Errorf("Type = %q; want tool", m.Type)
+	}
+	if len(m.Binaries) != 1 || m.Binaries[0] != "bin/example" {
+		t.Errorf("Binaries = %v", m.Binaries)
+	}
+	if !strings.Contains(m.Install, "make") {
+		t.Errorf("Install missing make: %q", m.Install)
+	}
+	if !strings.Contains(m.Uninstall, "rm -rf build") {
+		t.Errorf("Uninstall missing rm: %q", m.Uninstall)
+	}
+}
+
+func TestValidateNameAccepts(t *testing.T) {
+	good := []string{"seclists", "nuclei-templates", "powerlevel10k", "gf-patterns", "abc.def_ghi"}
+	for _, n := range good {
+		if err := ValidateName(n); err != nil {
+			t.Errorf("ValidateName(%q) = %v; want nil", n, err)
+		}
+	}
+}
+
+func TestValidateNameRejects(t *testing.T) {
+	bad := []string{"", "../etc/passwd", "name with space", "name|pipe", "name;rm", "name/slash", "..", "name$"}
+	for _, n := range bad {
+		if err := ValidateName(n); err == nil {
+			t.Errorf("ValidateName(%q) = nil; want error", n)
+		}
+	}
+}
+
+func TestSaveInstalledIsAtomic(t *testing.T) {
+	p := tempPaths(t)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatalf("EnsureDirs: %v", err)
+	}
+	// Save once to establish a known state.
+	first := &Installed{Plugins: map[string]InstalledEntry{
+		"a": {Type: "tool", Path: "/x", InstalledAt: "t1"},
+	}}
+	if err := p.SaveInstalled(first); err != nil {
+		t.Fatalf("first save: %v", err)
+	}
+	// Save again with different content.
+	second := &Installed{Plugins: map[string]InstalledEntry{
+		"b": {Type: "wordlist", Path: "/y", InstalledAt: "t2"},
+	}}
+	if err := p.SaveInstalled(second); err != nil {
+		t.Fatalf("second save: %v", err)
+	}
+	// No leftover temp files in $CSBX_HOME root.
+	entries, err := os.ReadDir(p.Home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "installed-") && e.Name() != "installed.yaml" {
+			t.Errorf("leftover temp file: %s", e.Name())
+		}
+	}
+	// Final state matches the second write.
+	round, err := p.LoadInstalled()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, has := round.Plugins["a"]; has {
+		t.Error("first-save 'a' still present; second save did not replace")
+	}
+	if _, has := round.Plugins["b"]; !has {
+		t.Error("second-save 'b' missing")
+	}
+}


### PR DESCRIPTION
Port cybersandbox plugin manager's read-only surface to Go: search, info, list, doctor. Mutating subcommands (install/remove/update/sync/ pdtm) and verify still resolve to the bash csbx via the not-yet-ported redirect; phases 3-2c (verify) and 3-3 (mutating) land them later.

## What's in

- cli/internal/csbx/state.go (300 lines): typed state layer.
  - Registry, RegistryEntry (with reserved fields for spec 012's signature_url/identity/oidc_issuer)
  - Installed, InstalledEntry (with optional Source for pdtm)
  - Manifest with hook script fields (install/post_install/uninstall)
  - Paths struct with NewPaths() honoring CSBX_HOME and CSBX_REGISTRY_URL env vars
  - EnsureDirs() — idempotent mkdir of bin + plugins/{tools,wordlists, nuclei-templates,themes,configs} + bootstrap installed.yaml
  - LoadRegistry / LoadInstalled / LoadManifest via generic loadYAMLFile[T]
  - SaveInstalled — atomic temp+rename
  - ValidateName — bash csbx:89-96 plus a hardening fix the audit flagged: bash lets bare "." and ".." through (only rejects "../" with trailing slash); the Go port rejects them explicitly because they're dangerous as path components

- cli/cmd/csbx/csbx.go: cobra subtree root, NewCmd() exported. Each subcommand lives in its own file so the surface stays browseable.

- cli/cmd/csbx/list.go (+ _test.go): `list` (installed) and `list --available` (registry catalog). Sorted alphabetically; text/tabwriter for column alignment.

- cli/cmd/csbx/doctor.go (+ _test.go): health check. Reports $CSBX_HOME tree, broken symlinks under bin/, git availability, installed plugin count, plugin storage size. Bash-compatible [✓]/[!]/[+]/[x] markers so test_csbx.sh keeps passing when the bash file becomes a shim.

- cli/cmd/csbx/search.go (+ _test.go): substring match against name + description + tags (case-insensitive, like the bash). Empty query lists all; no-match query prints stderr hint.

- cli/cmd/csbx/info.go (+ _test.go): registry detail + install status. Returns 0 even for unknown plugins (matches bash UX — "user-information" not "fatal error").

- cli/cmd/stubs.go: csbx full-stub removed; replaced by the real subtree wired in cli/cmd/root.go. invoke-ollama and harbinger stubs remain for now.

- cli/cmd/root.go: subcommand-status table flipped csbx to PARTIAL and explains the partial scope.

- cli/README.md: status table and layout diagram updated.

- cli/go.mod / go.sum: + gopkg.in/yaml.v3 v3.0.1.

## Verification

  cd cli
  go vet ./...                       → clean
  go test -race -count=1 ./...       → all 4 packages pass
                                       cli/cmd                     ok
                                       cli/cmd/csbx                ok (18 tests)
                                       cli/internal/anthropic      ok
                                       cli/internal/csbx           ok (12 tests)
  go build -o /tmp/cb .              → produces working binary

  /tmp/cb --help        → csbx shown as PARTIAL
  /tmp/cb csbx --help   → search/info/list/doctor listed
  /tmp/cb csbx doctor   → CyberSandbox Health Check + bash-compatible markers
  /tmp/cb csbx list     → "Installed plugins: (none — try: ...)"

## Audit cross-references

- cli/cmd/csbx/PORT_AUDIT.md (shipped on feat/spec-018-phase-3-csbx-audit) is the contract this implementation satisfies. The audit's typed- struct designs (Registry, Installed, Manifest) match what landed here exactly.

- The audit's two latent-bug callouts:
  * csbx.yaml.type path traversal — ValidateName is now reusable for manifest fields; phase 3-3b should call it on every type/name that gets composed into a path.
  * installed.yaml race — SaveInstalled is atomic (temp+rename). Cross-process locking is still pending; phase 3-3b adds a flock around the entire install transaction.

## What changed

<!-- Brief description -->

## Type

- [ ] Bug fix
- [ ] New feature
- [ ] New plugin (csbx registry)
- [ ] Docker/infra change
- [ ] Documentation

## Testing

<!-- How did you verify this works? -->

## Checklist

- [ ] Tested with `docker compose build`
- [ ] No secrets or .env files committed
- [ ] Updated SETUP.md if user-facing behavior changed
