### PR TITLE
chore(cli): remove dead strings import from invoke_ollama.go

### DIFF
--- a/cli/cmd/invoke_ollama.go
+++ b/cli/cmd/invoke_ollama.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"strconv"
-	"strings"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
@@ -171,6 +170,3 @@ func ollamaUsageStr(n int) string {
 	}
 	return strconv.Itoa(n)
 }
-
-// Compile-time guard: keep io.Writer reachable even if the file shrinks.
-var _ io.Writer = (*strings.Builder)(nil)


### PR DESCRIPTION
The phase-2 ollama port (#33) shipped with a stray "strings" import paired with a fake compile-time guard:

    var _ io.Writer = (*strings.Builder)(nil)

The guard doesn't guard anything — the file never uses io.Writer with strings.Builder. Removing the assertion lets us drop the unused "strings" import. No behaviour change; just cleanup.

  go vet ./...                 → clean
  go test -race -count=1 ./... → all 5 packages pass

## What changed

<!-- Brief description -->

## Type

- [ ] Bug fix
- [ ] New feature
- [ ] New plugin (csbx registry)
- [ ] Docker/infra change
- [ ] Documentation

## Testing

<!-- How did you verify this works? -->

## Checklist

- [ ] Tested with `docker compose build`
- [ ] No secrets or .env files committed
- [ ] Updated SETUP.md if user-facing behavior changed
